### PR TITLE
Version 1.0 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,8 +6,8 @@ Author  |  &ensp;E-Mail&ensp; | Copyright ©
  :----:  |  :----: | :--------- 
  Oscar Garcia-Montero  |  [✉](mailto:garcia@physik.uni-bielefeld.de) | `2022-`
 
-## Other contributions
+## External contributors
 
 Year  | Author | E-Mail
-:---: | :----: | :----:
-`2023`  | Hendrik Roch | [✉](mailto:roch@fias.uni-frankfurt.de)
+ :----:  |  :----: | :--------- 
+ Hendrik Roch | [✉](mailto:roch@fias.uni-frankfurt.de) | `2023-`

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,13 @@
+# Authors
+
+## Authors of the McDIPPER
+
+Author  |  &ensp;E-Mail&ensp; | Copyright © 
+ :----:  |  :----: | :--------- 
+ Oscar Garcia-Montero  |  [✉](mailto:garcia@physik.uni-bielefeld.de) | `2022-`
+
+## Other contributions
+
+Year  | Author | E-Mail
+:---: | :----: | :----:
+`2023`  | Hendrik Roch | [✉](mailto:roch@fias.uni-frankfurt.de)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,6 +8,6 @@ Author  |  &ensp;E-Mail&ensp; | Copyright ©
 
 ## External contributors
 
-Year  | Author | E-Mail
+Author  |  &ensp;E-Mail&ensp; | Copyright © 
  :----:  |  :----: | :--------- 
  Hendrik Roch | [✉](mailto:roch@fias.uni-frankfurt.de) | `2023-`

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,6 +8,6 @@ Author  |  &ensp;E-Mail&ensp; | Copyright ©
 
 ## External contributors
 
-Author  |  &ensp;E-Mail&ensp; | Copyright © 
+Author  |  &ensp;E-Mail&ensp; | Year
  :----:  |  :----: | :--------- 
  Hendrik Roch | [✉](mailto:roch@fias.uni-frankfurt.de) | `2023-`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,97 @@
+# minimum cmake version required
+cmake_minimum_required(VERSION 3.9)
+
+# name, version, description and language of the project
+project(McDIPPER VERSION 1.0
+        DESCRIPTION "Monte-Carlo Dipole Event-geneRator"
+        LANGUAGES CXX)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+    message(FATAL_ERROR "You don't want to configure in the source directory!")
+endif()
+
+if(NOT "{CMAKE_CXX_STANDARD}")
+    set(CMAKE_CXX_STANDARD 17)    
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC -O3")
+message(STATUS "CXX_FLAGS = " ${CMAKE_CXX_FLAGS})
+
+# Option for specifying GSL library path via command line
+option(GSL_PATH "Path to GSL library")
+
+# Look for GSL package
+find_package(GSL REQUIRED)
+if(GSL_FOUND)
+    message(STATUS "GSL found: ${GSL_INCLUDE_DIRS}")
+    include_directories(${GSL_INCLUDE_DIRS})
+    list(APPEND LIBRARIES_TO_LINK ${GSL_LIBRARIES})
+else()
+    message(STATUS "GSL not found. Using provided library path or defaults.")
+    if(NOT GSL_PATH)
+        message(FATAL_ERROR "GSL not found. Please specify the path to GSL library using -DGSL_PATH=<path>")
+    endif()
+endif()
+
+
+# Specifications for the Cuba library
+# Retrieve the CUBA_PATH variable if provided; otherwise, default to an empty string
+if(NOT DEFINED CUBA_PATH)
+    message(FATAL_ERROR "-DCUBA_PATH=<path> not given")
+endif()
+
+# Add Cuba library and source directories to the include path using the provided path
+include_directories(${CUBA_PATH})
+include_directories(${CUBA_PATH}/src)
+list(APPEND LIBRARIES_TO_LINK ${CUBA_PATH}/libcuba.a)
+
+
+
+
+# Option for specifying LHAPDF path via command line
+option(LHAPDF_PATH "Path to LHAPDF library")
+if(NOT LHAPDF_FOUND)
+    if(NOT LHAPDF_PATH)
+        message(FATAL_ERROR "LHAPDF not found. Please specify the path to LHAPDF library using -DLHAPDF_PATH=<path>")
+    endif()
+
+    # Include directories and link LHAPDF library if not found by find_package
+    include_directories(${LHAPDF_PATH}/include)
+    list(APPEND LIBRARIES_TO_LINK ${LHAPDF_PATH}/lib/libLHAPDF.a) # Adjust library file if needed
+endif()
+
+
+message(STATUS "LIBRARIES_TO_LINK = " ${LIBRARIES_TO_LINK})
+
+
+# Source files
+set(SRC
+    src/main.cpp
+    src/config.cpp
+    src/pdfs_lhapdf.cpp
+    src/nucleus.cpp
+    src/event.cpp
+    src/charges.cpp
+    src/dipole_ipsat.cpp
+    src/model_gbw.cpp
+    src/model_ipsat.cpp
+    # Add other source files here
+)
+
+file(COPY ${CMAKE_SOURCE_DIR}/ipsat DESTINATION  ${CMAKE_BINARY_DIR})
+
+# Create the executable
+add_executable(mcDipper ${SRC})
+
+
+# Link libraries
+target_link_libraries(mcDipper ${LIBRARIES_TO_LINK}) # Add more libraries here if needed
+
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ make
 ```
 and to run
 ```
-./mcDip -i config.yaml
+./mcDipper -i config.yaml
 ```
 
 ### Build with CMake

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # McDIPPER (Monte-Carlo Dipole Event-geneRator )
 
-The ```McDIPPER``` is a saturation-based heavy-ion initial condition MC generator. It used the input from diverse saturation models and fits to produce a 3D energy and charge deposition. 
+The ```McDIPPER``` is a saturation-based heavy-ion initial condition MC generator. It used the input from diverse saturation models and fits to produce a 3D energy and charge deposition. The main reference to cite is [2308.11713](https://arxiv.org/abs/2308.11713).
 
 ## Requisites 
 
@@ -36,7 +36,15 @@ and to run
 ```
 ./mcDip -i config.yaml
 ```
-This will change, as I change the configuration option.
+
+### Build with CMake
+
+In case someone wants to compile the code using `cmake`, there is the possibility to do so.
+```
+mkdir build && cd build
+cmake .. -DCUBA_PATH=<path> -DLHAPDF_PATH=<path>
+```
+
 
 ## The structure of the code
 
@@ -58,16 +66,7 @@ For the input needed in the simulation please see the example configuration file
 
 ## Output 
 
-There are three flags for 
-
-
-## Analysis suite
-
-Additionally, I have included a set of python classes that can help the user analyze data. These are stored in the ``` analysis ``` folder, and consist of
-
-```
-analysis/analysis
-```
+There are several options for output. Please see the documentation file. 
 
 ## Dealing with issues in MacOS 
 

--- a/configs/ipsat.yaml
+++ b/configs/ipsat.yaml
@@ -19,6 +19,7 @@ General:
     Impact:
         Range: [0, 40]
         Sampling: Quadratic
+    Seed: 1979994328
     PDFs:
       PDFSet: CT18NNLO
       ForcePositive: 1
@@ -40,7 +41,7 @@ Model_Parameters:
 
 Output:
     path_to_output: Runs/
-    run_name: PbPb_2760GeV_IPSat_Set1
-    Format: ["EMoments","NMoments","Charges"]
+    run_name: Test_Run
+    Format: ["EMoments","NMoments"]
     PrintAvg: False
     BoostInvariant: False

--- a/configs/ipsat.yaml
+++ b/configs/ipsat.yaml
@@ -36,7 +36,7 @@ Grid:
 Model_Parameters:
     Set:   1
     XScaling: 0.01
-    P_reg: 0.01 
+    P_reg: 0.1 
 
 Output:
     path_to_output: Runs/

--- a/configs/ipsat.yaml
+++ b/configs/ipsat.yaml
@@ -42,3 +42,5 @@ Output:
     path_to_output: Runs/
     run_name: PbPb_2760GeV_IPSat_Set1
     Format: ["EMoments","NMoments","Charges"]
+    PrintAvg: False
+    BoostInvariant: False

--- a/configs/ipsat.yaml
+++ b/configs/ipsat.yaml
@@ -4,7 +4,7 @@ Logging:
     Verbose: True
 
 General:
-    SqrtsNN: 2760.0
+    SqrtsNN: 5020.0
     Nucleus1:
         A:    208
         Z:    82
@@ -36,6 +36,7 @@ Grid:
 Model_Parameters:
     Set:   1
     XScaling: 0.01
+    P_reg: 0.01 
 
 Output:
     path_to_output: Runs/

--- a/src/charges.cpp
+++ b/src/charges.cpp
@@ -113,7 +113,7 @@ bool Charges::import_charges(){
   if(is_table_set){
     MakeGrid();
     import_is_success = import_is_success && read_in_energy_gluons();
-    if(config.get_Verbose()){std::cout<< "[ Charges ] Gluon energy density    -->  Imported "<< std::endl;}
+    if(config.get_Verbose()){std::cout<< "[ Charges ] Gluon energy density    -->  Imported " << std::endl;}
     import_is_success = import_is_success && read_in_nK_quark(0, QuarkID::u );
     import_is_success = import_is_success && read_in_nK_quark(1, QuarkID::u );
     if(config.get_Verbose()){std::cout<< "[ Charges ] U-Quark constructions   -->  Imported "<< std::endl;}

--- a/src/charges.cpp
+++ b/src/charges.cpp
@@ -31,13 +31,13 @@ Charges::Charges(Config ConfInput){
 }
 
 Charges::~Charges(){
-  for (size_t i = 0; i < NETA; i++) {
+  for (int i = 0; i < NETA; i++) {
     gsl_spline2d_free(e_g_spl[i]);
     gsl_interp_accel_free (xaccEG[i]);
     gsl_interp_accel_free (yaccEG[i]);
 	}
 
-  for (size_t i = 0; i < NQComp; i++) {
+  for (int i = 0; i < NQComp; i++) {
     gsl_spline2d_free(N0u_spl[i]);
     gsl_spline2d_free(N0d_spl[i]);
     gsl_spline2d_free(N0s_spl[i]);
@@ -230,7 +230,7 @@ std::string Charges::get_set_name(int n){
 
 void Charges::get_name_and_value(std::string testline,std::string &name, std::string &value){
   std::string line_temp= testline;
-  size_t pos = line_temp.find(":");
+  int pos = line_temp.find(":");
   name = line_temp.substr(0,pos);
   value = line_temp.substr(pos+1, line_temp.length()-pos );
   name.erase(std::remove(name.begin(),name.end(), ' '),name.end());
@@ -266,11 +266,11 @@ bool Charges::read_in_energy_gluons(){
         etau0_g[NX*i2+i1]=edensG_t;
       }
     }
-    for (size_t i1 = 0; i1 < NX; i1++) {T1array[i1]=T1Grid[i1]; }
-    for (size_t i2 = 0; i2 < NY; i2++) {T2array[i2]=T2Grid[NX*i2]; }
+    for (int i1 = 0; i1 < NX; i1++) {T1array[i1]=T1Grid[i1]; }
+    for (int i2 = 0; i2 < NY; i2++) {T2array[i2]=T2Grid[NX*i2]; }
 
-    size_t nx = sizeof(T1array) / sizeof(T1array[0]);
-    size_t ny = sizeof(T2array) / sizeof(T2array[0]);
+    int nx = sizeof(T1array) / sizeof(T1array[0]);
+    int ny = sizeof(T2array) / sizeof(T2array[0]);
 
     const gsl_interp2d_type *T= gsl_interp2d_bilinear;
     e_g_spl[iY] = gsl_spline2d_alloc(T, nx, ny);
@@ -316,10 +316,10 @@ bool Charges::read_in_nK_quark(int k, QuarkID qid){
   }
   fclose(table);
 
-  size_t neta = sizeof(Yarray) / sizeof(Yarray[0]);
-  size_t nx = sizeof(Tarray) / sizeof(Tarray[0]);
+  int neta = sizeof(Yarray) / sizeof(Yarray[0]);
+  int nx = sizeof(Tarray) / sizeof(Tarray[0]);
 
-  for (size_t ik = 0; ik < NQComp; ik++) {
+  for (int ik = 0; ik < NQComp; ik++) {
     const gsl_interp2d_type *T= gsl_interp2d_bilinear;
     if(k==0){
       if(qid==QuarkID::u){
@@ -603,7 +603,7 @@ void Charges::dump_charges(double T1,double T2){
   densityname << path_to_set <<"/charges_dump_T1_"<< T1<< "_T2_"<< T2<<".dat";
 	density_f.open(densityname.str());
 
-	for (size_t iy = 0; iy < config.get_NETA(); iy++) {
+	for (int iy = 0; iy < config.get_NETA(); iy++) {
 		double y_t = iy*config.get_dETA() + config.get_ETAMIN();
 		// density_f<< std::endl;
     density_f<<y_t<< "\t"<<gluon_energy(y_t, T1,T2);
@@ -625,9 +625,9 @@ void Charges::dump_charges_eta(double eta ){
   double Tmax_t=8.;
   double Tmin_t=0;
   double dT_t= (Tmax_t-Tmin_t)/(double(NX) - 1.);
-  for (size_t i1 = 0; i1 < NX; i1++) {
+  for (int i1 = 0; i1 < NX; i1++) {
     double T1= i1*dT_t + Tmin_t;
-    for (size_t i2 = 0; i2 < NY; i2++) {
+    for (int i2 = 0; i2 < NY; i2++) {
       double T2= i2*dT_t + Tmin_t;
       density_f<<T1<< "\t"<<T2<< "\t"<<gluon_energy(eta, T1,T2);
       density_f<< "\t"<<quark_energy(eta, T1,T2);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -243,7 +243,7 @@ void Config::write_config_file(std::string target_folder){}
 void Config::terminal_setup_output(){
   std::cout<< "|----------------------------------------------------------------------------------------|"<<std::endl;
   std::cout<< "|----------------------------------------------------------------------------------------|"<<std::endl;
-  std::cout<< "                             Running McDip. Version " << version <<std::endl;
+  std::cout<< "                             Running McDipper. Version " << version <<std::endl;
   std::cout<< "|----------------------------------------------------------------------------------------|"<<std::endl;
   std::cout<< "|------------------------------- General Parameters -------------------------------------|\n";
   std::cout<< "       Running model: " << cModelStr << " for sqrt(S)= "<<sqrtsNN << "\n";

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -227,6 +227,14 @@ void Config::process_output_parameters(std::string testline){
     remove_char(value_t,'"');
     format[n_formats-1] = value_t;
   }
+  if(name_t == "PrintAvg"){
+    if(value_t == "False"){print_avg=0;}
+    else if(value_t == "ObservablesOnly"){print_avg=1;}
+    else if(value_t == "True"){print_avg=2;}
+    else{std::cerr<<"Error: Average-Event output mode not implemented! Exiting.";exit(EXIT_FAILURE);}
+  }
+  if(name_t == "BoostInvariant"){ boost_invariant= make_bool(value_t);}
+  // 
  
 }
  
@@ -263,8 +271,16 @@ void Config::terminal_setup_output(){
   }
   std::cout<< "|-------------------------------------- Output ------------------------------------------|\n";
   std::cout<< "  Writing output to : " << path_to_output << " \n";
+  std::cout<< "  Boost invariant output : " ;
+  if(boost_invariant){ std::cout<<"True\n";}
+  else{ std::cout<<"False\n";}
   std::cout<< "  Chosen output Formats : ";
   for (size_t i = 0; i < n_formats; i++) { if(i==n_formats-1){std::cout<< format[i] << "\n";}else{std::cout<< format[i] << ", ";}}
+  std::cout<< "  Average Event output: ";
+  if(print_avg==0){std::cout<< "None \n";}
+  else if(print_avg==1){std::cout<< "Only Observables \n";}
+  else if(print_avg==2){std::cout<< "All \n";}
+  else{std::cerr<<"Error: Average-Event output mode not implemented! Exiting.";exit(EXIT_FAILURE);}
   std::cout<< "|----------------------------------------------------------------------------------------|\n";
 }
 
@@ -334,6 +350,13 @@ void Config::dump(std::string OUTPATH){
   config_f << "    path_to_output: "<< path_to_output<<"\n";
   config_f << "    Format:  [";
   for (size_t i = 0; i < n_formats; i++) { if(i==n_formats-1){config_f << "\"" << format[i] << "\"]\n";}else{config_f << "\"" << format[i] << "\", ";}}
+  config_f << "PrintAvg: ";
+  if(print_avg==0){config_f<< "False\n";}
+  else if(print_avg==1){config_f<< "ObservablesOnly\n";}
+  else if(print_avg==2){config_f<< "True\n";}
+  config_f<< "  BoostInvariant: " ;
+  if(boost_invariant){ config_f<<"True\n";}
+  else{ config_f<<"False\n";}
   config_f << "\n";
 config_f.close();
 }
@@ -477,6 +500,8 @@ Config::Config(const Config& OldConf){
    run_name=OldConf.run_name;
    is_run_renamed=OldConf.is_run_renamed;
    format=new std::string[n_formats];
+   print_avg=OldConf.print_avg;
+   boost_invariant=OldConf.boost_invariant;
    for (size_t i = 0; i < n_formats; i++) {format[i]=OldConf.format[i];}
    //Thickness_Parameters
    TMax= OldConf.TMax;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -65,7 +65,7 @@ void Config::process_parameters(){
 
 void Config::check_version(std::string testline){
   std::string line_temp= testline;
-  size_t pos = line_temp.find(":");
+  int pos = line_temp.find(":");
   version = line_temp.substr(pos+1, line_temp.length()-pos );
   version.erase(std::remove(version.begin(), version.end(), ' '), version.end());
   /// Later on, checks version and if not compatible, exits. For now this is just a placeholder.
@@ -216,8 +216,8 @@ void Config::process_output_parameters(std::string testline){
     n_formats = 1 + std::count(value_t.begin(), value_t.end(), ',');
     format=new std::string[n_formats];
     remove_char(value_t,'[');remove_char(value_t,']');
-    size_t pos = 0;
-    for (size_t i = 0; i < n_formats-1; i++) {
+    int pos = 0;
+    for (int i = 0; i < n_formats-1; i++) {
       pos = value_t.find(delimiter);
       token = value_t.substr(0, pos);
       value_t.erase(0, pos + delimiter.length());
@@ -275,7 +275,7 @@ void Config::terminal_setup_output(){
   if(boost_invariant){ std::cout<<"True\n";}
   else{ std::cout<<"False\n";}
   std::cout<< "  Chosen output Formats : ";
-  for (size_t i = 0; i < n_formats; i++) { if(i==n_formats-1){std::cout<< format[i] << "\n";}else{std::cout<< format[i] << ", ";}}
+  for (int i = 0; i < n_formats; i++) { if(i==n_formats-1){std::cout<< format[i] << "\n";}else{std::cout<< format[i] << ", ";}}
   std::cout<< "  Average Event output: ";
   if(print_avg==0){std::cout<< "None \n";}
   else if(print_avg==1){std::cout<< "Only Observables \n";}
@@ -349,7 +349,7 @@ void Config::dump(std::string OUTPATH){
   config_f << "Output:\n";
   config_f << "    path_to_output: "<< path_to_output<<"\n";
   config_f << "    Format:  [";
-  for (size_t i = 0; i < n_formats; i++) { if(i==n_formats-1){config_f << "\"" << format[i] << "\"]\n";}else{config_f << "\"" << format[i] << "\", ";}}
+  for (int i = 0; i < n_formats; i++) { if(i==n_formats-1){config_f << "\"" << format[i] << "\"]\n";}else{config_f << "\"" << format[i] << "\", ";}}
   config_f << "PrintAvg: ";
   if(print_avg==0){config_f<< "False\n";}
   else if(print_avg==1){config_f<< "ObservablesOnly\n";}
@@ -428,7 +428,7 @@ std::string Config::get_header(std::string testline){
 
 void Config::get_name_and_value(std::string testline,std::string &name, std::string &value){
   std::string line_temp= testline;
-  size_t pos = line_temp.find(":");
+  int pos = line_temp.find(":");
   name = line_temp.substr(0,pos);
   value = line_temp.substr(pos+1, line_temp.length()-pos );
   name.erase(std::remove(name.begin(),name.end(), ' '),name.end());
@@ -446,7 +446,7 @@ bool Config::make_bool(std::string boolstr){
 void Config::retrieve_range(std::string rangestring, double &xmin, double &xmax){
     std::string tempstr=rangestring;
     remove_char(tempstr,'[');remove_char(tempstr,']');
-    size_t pos = tempstr.find(",");
+    int pos = tempstr.find(",");
     std::string min = tempstr.substr(0,pos);
     std::string max = tempstr.substr(pos+1, tempstr.length()-pos );
     min.erase(std::remove(min.begin(),min.end(), ' '),min.end());
@@ -492,7 +492,7 @@ Config::Config(const Config& OldConf){
    dX=OldConf.dX;dY=OldConf.dY;dETA=OldConf.dETA; /* fm */
    BG = OldConf.BG; /// In fm^2
    // Model Parameters
-   for (size_t i = 0; i < 10; i++) {ModelPars[i]=OldConf.ModelPars[i];}
+   for (int i = 0; i < 10; i++) {ModelPars[i]=OldConf.ModelPars[i];}
    NModelParams=OldConf.NModelParams;
    //OutPut params
    n_formats= OldConf.n_formats;
@@ -502,7 +502,7 @@ Config::Config(const Config& OldConf){
    format=new std::string[n_formats];
    print_avg=OldConf.print_avg;
    boost_invariant=OldConf.boost_invariant;
-   for (size_t i = 0; i < n_formats; i++) {format[i]=OldConf.format[i];}
+   for (int i = 0; i < n_formats; i++) {format[i]=OldConf.format[i];}
    //Thickness_Parameters
    TMax= OldConf.TMax;
    TMin= OldConf.TMin;
@@ -531,7 +531,7 @@ bool Config::compare_model_parameters (Config * OldConf, double tolerance){
   bool is_equal=false;
   if(cModel == OldConf->get_model()){
     is_equal=true;
-    for (size_t i = 0; i < get_mpars_number(); i++) {
+    for (int i = 0; i < get_mpars_number(); i++) {
       if(ModelPars[i]==0 && OldConf->get_ModelParams(i) == 0){continue;}
       else{
         double diff = NDiff(ModelPars[i],OldConf->get_ModelParams(i));

--- a/src/dipole_ipsat.cpp
+++ b/src/dipole_ipsat.cpp
@@ -171,8 +171,8 @@ Dipole::Dipole(int set, bool Verbose){
 		}
 	}
 
-	size_t ny = sizeof(Y) / sizeof(Y[0]);
-	size_t nu = sizeof(u) / sizeof(u[0]);
+	int ny = sizeof(Y) / sizeof(Y[0]);
+	int nu = sizeof(u) / sizeof(u[0]);
 
 	const gsl_interp2d_type *T= gsl_interp2d_bicubic;
 	G_spl = gsl_spline2d_alloc(T, ny, nu);
@@ -215,7 +215,7 @@ Dipole::~Dipole(){
   	gsl_interp_accel_free (xaccPP);
 		gsl_interp_accel_free (yaccPP);
 
-		for (size_t i = 0; i < IPsat_pars::NY; i++) {
+		for (int i = 0; i < IPsat_pars::NY; i++) {
 	    gsl_spline2d_free(DA_spl[i]);
 	    gsl_spline2d_free(DF_spl[i]);
 	    gsl_interp_accel_free (xaccA[i]);
@@ -631,16 +631,16 @@ void Dipole::Make_Dipole_Grids(){
 	// First Make the K-grid
 	k_grid_homo= new double[N1];
 	q_grid_homo= new double[N1];
-	for (size_t ik = 0; ik < N1; ik++) {
+	for (int ik = 0; ik < N1; ik++) {
 			q_grid_homo[ik]=ik*DK;
 			k_grid_homo[ik]=K_MIN*exp(ik*DK);
 	}
 
 	Y_grid= new double[N2];
-	for (size_t iy = 0; iy < N2; iy++) {Y_grid[iy]=Y_MIN + iy*DY;}
+	for (int iy = 0; iy < N2; iy++) {Y_grid[iy]=Y_MIN + iy*DY;}
 
 	T_grid= new double[N3];
-	for (size_t iT = 0; iT < N3; iT++) {T_grid[iT]=T_MIN + iT*DT;}
+	for (int iT = 0; iT < N3; iT++) {T_grid[iT]=T_MIN + iT*DT;}
 
 	if(DipVerbose){std::cout<<"---> Grid created for Dipoles with Nk = " << N1<< " and  NY = " << N2<<std::endl;}
 	is_initialized=true;
@@ -708,10 +708,10 @@ void Dipole::Transform_Dipole(Rep rep){
 	}  
 	dip_f.open(path_to_dip.str());
 
-	for (size_t iT = 0; iT < IPsat_pars::T_dip_points; iT++) {
+	for (int iT = 0; iT < IPsat_pars::T_dip_points; iT++) {
 		T_t=IPsat_pars::T_dip_min + iT * IPsat_pars::T_dip_dT;
 
-		for (size_t iy = 0; iy < N2; iy++) {
+		for (int iy = 0; iy < N2; iy++) {
 			x_t=get_X(Y_grid[iy]);
 			// Set Hankel Environment around the characteristic scale of the the dipole
 			RDom_t= EffectiveRadius(2,x_t,T_t,rep);
@@ -720,7 +720,7 @@ void Dipole::Transform_Dipole(Rep rep){
 				if(DipVerbose){ std::cout<< "Transforming for discretized function using "<< Hank.get_Npoints() << " points "<<std::endl; }
 			}
 			//Set points
-			for (size_t ix = 0; ix < Hank.get_Npoints(); ix++) {
+			for (int ix = 0; ix < Hank.get_Npoints(); ix++) {
 				if(rep==Rep::Fundamental){
 					Hank.set_FX(ix,FundamentalDipole(x_t,Hank.get_X(ix),T_t)) ;
 				}else if(rep==Rep::Adjoint){
@@ -734,7 +734,7 @@ void Dipole::Transform_Dipole(Rep rep){
 			double k_int_grid[Hank.get_Npoints()];
 			double Dk_int_grid[Hank.get_Npoints()];
 
-			for (size_t ik = 0; ik < Hank.get_Npoints(); ik++) {
+			for (int ik = 0; ik < Hank.get_Npoints(); ik++) {
 				// Important to get the right UNITS!!
 				// k needs conversion fm^{-1}-> GeV
 				// Dk needs conversion fm^{2}-> GeV^{-2}
@@ -750,7 +750,7 @@ void Dipole::Transform_Dipole(Rep rep){
 
 
 			// Here extrapolation goes on
-			for (size_t iq = 0; iq < N1; iq++) {
+			for (int iq = 0; iq < N1; iq++) {
 
 				if(k_grid_homo[iq]>k_int_grid[Hank.get_Npoints()-1]){ Dip_k =0;}
 				else if(k_grid_homo[iq]<k_int_grid[0]){
@@ -802,12 +802,12 @@ void Dipole::Transform_Dipole_Naive(Rep rep){
 	}
 	dip_f.open(path_to_dip.str());
 
-	for (size_t iT = 0; iT < IPsat_pars::T_dip_points; iT++) {
+	for (int iT = 0; iT < IPsat_pars::T_dip_points; iT++) {
 		T_t=IPsat_pars::T_dip_min + iT * IPsat_pars::T_dip_dT;
 
-		for (size_t iy = 0; iy < N2; iy++) {
+		for (int iy = 0; iy < N2; iy++) {
 			x_t=get_X(Y_grid[iy]);
-			for (size_t ik = 0; ik < N1; ik++) {
+			for (int ik = 0; ik < N1; ik++) {
 				if(T_t==0){
 					dip_f<< T_t<<"\t"<< Y_grid[iy]<<"\t"<< q_grid_homo[ik]<<"\t" << 0 << std::endl;
 				}
@@ -846,7 +846,7 @@ void Dipole::Transform_Dipole_Naive_Test(Rep rep,double Tt){
 	double y[ Nx_t ];
 	double Y_MIN_OUT = Y_MIN *1.01;
 	double Y_MAX_OUT = Y_MAX *0.99;
-	for (size_t iy = 0; iy < Nx_t; iy++) {
+	for (int iy = 0; iy < Nx_t; iy++) {
  		y[iy] = Y_MIN_OUT + iy*(Y_MAX_OUT-Y_MIN_OUT)/(Nx_t-1.);
 		x[iy] = get_X(y[iy]);
 	}
@@ -865,17 +865,13 @@ void Dipole::Transform_Dipole_Naive_Test(Rep rep,double Tt){
 	}
 	dip_f.open(path_to_dip.str());
 	dip_f<< "# k";
-	for (size_t ix = 0; ix < Nx_t; ix++) {dip_f<< "\t D(x="<<x[ix]<<")";}
+	for (int ix = 0; ix < Nx_t; ix++) {dip_f<< "\t D(x="<<x[ix]<<")";}
 	dip_f<< std::endl;
 
-	for (size_t ik = 0; ik < N1; ik++) {
+	for (int ik = 0; ik < N1; ik++) {
 		dip_f<< K_MIN*exp(q_grid_homo[ik]);
-		for (size_t iy = 0; iy < Nx_t; iy++) {
+		for (int iy = 0; iy < Nx_t; iy++) {
 			x_t=get_X(y[iy]);
-
-			// DipFT HTPars={k_grid_homo[ik],x_t,Tt,this};
-			// if(rep==Rep::Fundamental){Dip_k = HankelDipole::DipoleFunFT(&HTPars);}
-			// else if(rep==Rep::Adjoint){Dip_k = HankelDipole::DipoleAdjFT(&HTPars);}
 			DipFT HTPars={k_grid_homo[ik]*gen_pars::GeV_to_fmm1,x_t,Tt,this};
 			if(rep==Rep::Fundamental){Dip_k = HankelDipole::DipoleFunFT(&HTPars)*gen_pars::fm2_to_GeVm2;}
 			else if(rep==Rep::Adjoint){Dip_k = HankelDipole::DipoleAdjFT(&HTPars)*gen_pars::fm2_to_GeVm2;}
@@ -895,7 +891,7 @@ double Dipole::MomentDipole(int n, double x, double T, Rep rep){
 	double r_t,u_t,c_n;
 	double MomentSum=0;
 
-	for (size_t iu = 0; iu < IPsat_pars::N_UMAX_INT; iu++) {
+	for (int iu = 0; iu < IPsat_pars::N_UMAX_INT; iu++) {
 		 u_t= IPsat_pars::du*iu;
 		 r_t= IPsat_pars::rmin*exp(u_t);
 		 if(iu==0 || iu==IPsat_pars::N_UMAX_INT-1){c_n=1/2.;}
@@ -917,8 +913,8 @@ double Dipole::EffectiveRadius(int n, double x, double T, Rep rep){
 
 double Dipole::FundamentalDipole_k(double x, double k, double T){
 	double tmp=0;
-
-	if ( k<0 || k >= K_MAX ){return 0.0;}
+	if( x>=0.999 ){return 0.0;}
+	else if ( k<0 || k >= K_MAX ){return 0.0;}
 	else if ( T <= T_MIN || T >= T_MAX ){return 0.0;}
 	else if(x <= X_MIN ){return 0;}
 	else{
@@ -928,13 +924,13 @@ double Dipole::FundamentalDipole_k(double x, double k, double T){
 			double Q20= gsl_spline2d_eval(Q2F_spl,T,Y0,xaccQ2F, yaccQ2F);
 			double Q2X; 
 			if ( x > X_MAX ){
-				double x1= get_X(Y_grid[N2-1]);
-				double x2= get_X(Y_grid[N2-2]);
-				double Q21= gsl_spline2d_eval(Q2F_spl,T,Y_grid[N2-1],xaccQ2F, yaccQ2F);
-				double Q22= gsl_spline2d_eval(Q2F_spl,T,Y_grid[N2-2],xaccQ2F, yaccQ2F);
+				double x1= get_X(Y_grid[0]);
+				double x2= get_X(Y_grid[1]);
+				double Q21= gsl_spline2d_eval(Q2F_spl,T,Y_grid[0],xaccQ2F, yaccQ2F);
+				double Q22= gsl_spline2d_eval(Q2F_spl,T,Y_grid[1],xaccQ2F, yaccQ2F);
 				double b= log(Q21/Q22)/ log(  (1-x1)/(1-x2) );
 				double a= Q21 *pow(1-x1,-b);
-				Q2X = a*pow(1-x,2.);
+				Q2X = a*pow(1-x,b);
 			}
 			else{
 				Q2X = gsl_spline2d_eval(Q2A_spl,T,Y_t,xaccQ2A, yaccQ2A);
@@ -983,9 +979,10 @@ double Dipole::FundamentalDipole_k(double x, double k, double T){
 
 double Dipole::AdjointDipole_k(double x, double k, double T){
 	double tmp=0;
-	if (  k<0 || k >= K_MAX ){return 0.0;}
-	else if ( T <= T_MIN || T >= T_MAX ){return 0.0;}
-	else if(x <= X_MIN ){return 0.0;}
+	if( x>=0.999 ){tmp=0.0;}
+	else if (  k<0 || k >= K_MAX ){tmp=0.0;}
+	else if ( T <= T_MIN || T >= T_MAX ){tmp=0.0;}
+	else if(x <= X_MIN ){tmp=0.0;}
 	else{
 		double Y_t = get_Y(x);
 		if(x > xscaling){
@@ -993,18 +990,19 @@ double Dipole::AdjointDipole_k(double x, double k, double T){
 			double Q20= gsl_spline2d_eval(Q2A_spl,T,Y0,xaccQ2A, yaccQ2A);
 			double Q2X; 
 			if ( x > X_MAX ){
-				double x1= get_X(Y_grid[N2-1]);
-				double x2= get_X(Y_grid[N2-2]);
-				double Q21= gsl_spline2d_eval(Q2A_spl,T,Y_grid[N2-1],xaccQ2A, yaccQ2A);
-				double Q22= gsl_spline2d_eval(Q2A_spl,T,Y_grid[N2-2],xaccQ2A, yaccQ2A);
+				double x1= get_X(Y_grid[0]);
+				double x2= get_X(Y_grid[1]);
+				double Q21= gsl_spline2d_eval(Q2A_spl,T,Y_grid[0],xaccQ2A, yaccQ2A);
+				double Q22= gsl_spline2d_eval(Q2A_spl,T,Y_grid[1],xaccQ2A, yaccQ2A);
 				double b= log(Q21/Q22)/ log(  (1-x1)/(1-x2) );
 				double a= Q21 *pow(1-x1,-b);
-				Q2X = a*pow(1-x,2.);
+				Q2X = a*pow(1-x,b);
 			}
 			else{
 				Q2X = gsl_spline2d_eval(Q2A_spl,T,Y_t,xaccQ2A, yaccQ2A);
 			}
 			tmp= (Q20/Q2X)*AdjointDipole_k(xscaling, k * sqrt(Q20/Q2X), T);
+			// if(tmp!=tmp){std::cerr<<"TEST"<<x<<"\t"<<k<<"\t"<<T<< std::endl;}
 
 		}
 		else{
@@ -1047,8 +1045,6 @@ double Dipole::AdjointDipole_k(double x, double k, double T){
 	return tmp;
 }
 
-
-
 //////////////////////////////////////////////////////////
 //////              Importing Methods             ////////
 //////////////////////////////////////////////////////////
@@ -1070,15 +1066,15 @@ bool Dipole::import_dipole(Rep dipole_rep){
 
   double Yarray[N2];
 	double Qarray[N1];
-	for (size_t iY = 0; iY < N2; iY++) {Yarray[iY]= Y_MIN + iY*DY;}
-	for (size_t iQ = 0; iQ < N1; iQ++) {Qarray[iQ]= iQ*DK;}
+	for (int iY = 0; iY < N2; iY++) {Yarray[iY]= Y_MIN + iY*DY;}
+	for (int iQ = 0; iQ < N1; iQ++) {Qarray[iQ]= iQ*DK;}
 
 	//
 	FILE *table = fopen(tablename.str().c_str(),"r");
   double T_t,y_t,q_t,Dip_t;
-	for (size_t iT = 0; iT < N3; iT++) {
-		for (size_t iY = 0; iY < N2; iY++) {
-			for (size_t iq = 0; iq < N1; iq++) {
+	for (int iT = 0; iT < N3; iT++) {
+		for (int iY = 0; iY < N2; iY++) {
+			for (int iq = 0; iq < N1; iq++) {
 				if (fscanf(table,"%lf %lf %lf %lf", &T_t, &y_t, &q_t, &Dip_t) != 4){printf("Error reading distribution table!\n");exit(1);}
 				DipArray[N1*iY + iq]=Dip_t;
 			}
@@ -1137,7 +1133,7 @@ std::string Dipole::get_set_name(int n){
 
 void Dipole::get_name_and_value(std::string testline,std::string &name, std::string &value){
   std::string line_temp= testline;
-  size_t pos = line_temp.find(":");
+  int pos = line_temp.find(":");
   name = line_temp.substr(0,pos);
   value = line_temp.substr(pos+1, line_temp.length()-pos );
   name.erase(std::remove(name.begin(),name.end(), ' '),name.end());
@@ -1378,7 +1374,7 @@ void Dipole::dump_transformed_norm(double T){
 	int Nx_t = 100;
 	double Y_MIN_OUT = Y_MIN *1.01;
 	double Y_MAX_OUT = Y_MAX *0.99;
-	for (size_t iy = 0; iy <Nx_t; iy++) {
+	for (int iy = 0; iy <Nx_t; iy++) {
  		double y_t = Y_MIN_OUT + iy*(Y_MAX_OUT-Y_MIN_OUT)/(Nx_t-1.);
 		double x_t = get_X(y_t);
 		dip_A_f<< x_t << "\t" <<AdjointDipole_k(x_t,0, T) << std::endl  ;
@@ -1394,7 +1390,7 @@ void Dipole::dump_momentum_Dipole(double T){
 	double y[ Nx_t ];
 	double Y_MIN_OUT = Y_MIN *1.01;
 	double Y_MAX_OUT = Y_MAX *0.99;
-	for (size_t iy = 0; iy < Nx_t; iy++) {
+	for (int iy = 0; iy < Nx_t; iy++) {
  		y[iy] = Y_MIN_OUT + iy*(Y_MAX_OUT-Y_MIN_OUT)/(Nx_t-1.);
 		x[iy] = get_X(y[iy]);
 	}
@@ -1411,21 +1407,21 @@ void Dipole::dump_momentum_Dipole(double T){
 	dip_A_f<< "# k";
 	dip_F_f<< "# k";
 
-	for (size_t ix = 0; ix < Nx_t; ix++) {
+	for (int ix = 0; ix < Nx_t; ix++) {
 		dip_A_f<< "\tQ2(x="<<x[ix]<<")\t D(x="<<x[ix]<<")";
 		dip_F_f<< "\tQ2(x="<<x[ix]<<")\t D(x="<<x[ix]<<")";
 	}
 	dip_A_f<< std::endl;
 	dip_F_f<< std::endl;
 
-	for (size_t ik = 0; ik < N1; ik++) {
+	for (int ik = 0; ik < N1; ik++) {
 		double q_t = ik*DK;
 		double k_t = K_MIN*exp(q_t );
 
 		dip_A_f<< k_t ;
 		dip_F_f<< k_t ;
 
-		for (size_t j = 0; j < Nx_t; j++) {
+		for (int j = 0; j < Nx_t; j++) {
 			double Q2A_t= gsl_spline2d_eval(Q2A_spl,T,y[j],xaccQ2A, yaccQ2A);
 			double Q2F_t= gsl_spline2d_eval(Q2F_spl,T,y[j],xaccQ2F, yaccQ2F);
 
@@ -1477,16 +1473,16 @@ void Dipole::get_Q2(){
 	//Output to plot out the Scaling Q
 	double T_t, x_t;
 	int ix;
-	for (size_t iT = 0; iT < N3; iT++) {
+	for (int iT = 0; iT < N3; iT++) {
 		T_t=T_MIN + iT * DT;
-		for (size_t iy = 0; iy < N2; iy++) {
+		for (int iy = 0; iy < N2; iy++) {
 			x_t=get_X(Y_grid[iy]);
 
 			// Find  Q2 for both representations
 			bool is_adj_found=false;
 			bool is_fund_found=false;
 
-			for (size_t iu = 0; iu < IPsat_pars::NR - 1; iu++) {
+			for (int iu = 0; iu < IPsat_pars::NR - 1; iu++) {
 				double r1 = IPsat_pars::rmin *exp(iu*IPsat_pars::du);
 				double r2 = IPsat_pars::rmin *exp( (iu+1)*IPsat_pars::du);
 
@@ -1520,9 +1516,9 @@ void Dipole::get_Q2(){
 	}
 
 	//Output to plot out the Scaling Q
-	for (size_t iT = 0; iT < N3; iT++) {
+	for (int iT = 0; iT < N3; iT++) {
 		T_t=T_MIN + iT * DT;
-		for (size_t iy = 0; iy < N2; iy++) {
+		for (int iy = 0; iy < N2; iy++) {
 			ix= N2-1-iy;
 			x_t=get_X(Y_grid[ix]);
 			Q2_scaling_f<< T_t << "\t"<< x_t<< "\t"<< Q2F[N3*ix+iT]<< "\t"<< Q2A[N3*ix+iT] << std::endl;

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -27,6 +27,7 @@ Event::Event(Config ConfInput){
 	N2.A=config.get_A(2);N2.Z=config.get_Z(2);N2.mode=config.get_NuclearMode(2);
 
 	PrimalSeed=config.get_seed();
+	srand48(PrimalSeed);
 
 	b1=new double[2];
 	b2=new double[2];
@@ -124,14 +125,15 @@ double& Event:: nsAvg (int64_t ieta, int64_t nx, int64_t ny){return (nsAvg_ptr)[
 
 void Event::NewEvent(int EventID_in){
 	EventID=EventID_in;
-	EventSeed =std::rand(); //  CHECK THIS !
+	// EventSeed =std::rand(); //  CHECK THIS !
 
-	srand48(EventSeed);// Dump this in the config?
+	// srand48(EventSeed);// Dump this in the config?
 	// Create Nuclei
 	bool is_event_valid=false;
 	if(config.get_Verbose()){
 		std::cout<< "|---------------------------------- New Event: "<< EventID+1<<"/"<< config.get_NEvents() << " -------------------------------------|\n";
-		std::cout<< "    Event ID: " <<EventID << "       Event Seed: " << EventSeed << "\n"<<std::endl;}
+		std::cout<< "                       Event ID: " <<EventID <<std::endl;
+	}
 
 	while(!is_event_valid){
 
@@ -1052,8 +1054,6 @@ void Event::MakeGlobalQuantities_AverageEvent(){
 	global_f.open(global_name.str(), std::ios_base::app);
 
 	double eg_t,eq_t,nu_t,nd_t,ns_t;
-	double t1p_t,t1n_t,t2p_t,t2n_t;
-	// double t1_t,t2_t;
 
 	double total_energy_event_q=0;
 	double total_energy_event_g=0;
@@ -1096,12 +1096,6 @@ void Event::MakeGlobalQuantities_AverageEvent(){
 				double x_t= get_x(ix);
 				double y_t= get_y(iy);
 
-				t1p_t=T1p(ix,iy);
-				t1n_t=T1n(ix,iy);
-				t2p_t=T2p(ix,iy);
-				t2n_t=T2n(ix,iy);
-				// t1_t = t1p_t+t1n_t;
-				// t2_t = t2p_t+t2n_t;
 
 				eg_t= EgAvg (ieta, ix, iy);
 				eq_t= EqAvg (ieta, ix, iy);
@@ -1245,8 +1239,6 @@ void Event::MakeChargeOutput_AverageEvent(){
 	}
 
 	double eg_t,eq_t,nu_t,nd_t,ns_t;
-	double t1p_t,t1n_t,t2p_t,t2n_t;
-	// double t1_t,t2_t;
 
 
 	if(config.get_Verbose()){std::cout<< "\nWriting out charges and moments for Average Event "<<std::endl;}
@@ -1280,13 +1272,6 @@ void Event::MakeChargeOutput_AverageEvent(){
 
 				double x_t= get_x(ix)-x_cm_global;
 				double y_t= get_y(iy)-y_cm_global;
-
-				t1p_t=T1p(ix,iy);
-				t1n_t=T1n(ix,iy);
-				t2p_t=T2p(ix,iy);
-				t2n_t=T2n(ix,iy);
-				// t1_t = t1p_t+t1n_t;
-				// t2_t = t2p_t+t2n_t;
 
 				eg_t= EgAvg (ieta, ix, iy);
 				eq_t= EqAvg (ieta, ix, iy);

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -11,7 +11,8 @@
 #include "include/params_gen.h"
 // #include "include/params_gen.h"
 
-#define OPTICAL 1
+#define OPTICAL 0
+#define AVG_EVENT 0
 namespace fs = std::filesystem;
 
 #define PBSTR "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
@@ -34,14 +35,16 @@ Event::Event(Config ConfInput){
 
 	NX=config.get_NX();
 	NY=config.get_NY();
+	NETA= config.get_NETA();
 	MakeGrid();
-
+	if(config.print_avg_event()>0){InitializeAverageEvent();}
+	
 	ChargeMaker = new Charges(config);
-
+	
 	Initialize_output();
 
 	cell_trans_volume=config.get_dX()*config.get_dY();
-
+	
 }
 
 Event::~Event(){
@@ -51,14 +54,31 @@ Event::~Event(){
 	delete[] T1n_ptr;
 	delete[] T2p_ptr;
 	delete[] T2n_ptr;
+
+	if(config.print_avg_event()>0){
+		delete[] EgAvg_ptr;
+		delete[] EqAvg_ptr;
+		delete[] nuAvg_ptr;
+		delete[] ndAvg_ptr;
+		delete[] nsAvg_ptr;
+	}
 }
 
 // Structural Functions
 void Event::MakeGrid(){
+
 	T1p_ptr = new double[config.get_NX() * config.get_NY()];
 	T1n_ptr = new double[config.get_NX() * config.get_NY()];
 	T2p_ptr = new double[config.get_NX() * config.get_NY()];
 	T2n_ptr = new double[config.get_NX() * config.get_NY()];
+	
+	if(config.print_avg_event()>0){
+		EgAvg_ptr = new double[config.get_NETA() * config.get_NX() * config.get_NY()];
+		EqAvg_ptr = new double[config.get_NETA() * config.get_NX() * config.get_NY()];
+		nuAvg_ptr = new double[config.get_NETA() * config.get_NX() * config.get_NY()];
+		ndAvg_ptr = new double[config.get_NETA() * config.get_NX() * config.get_NY()];
+		nsAvg_ptr = new double[config.get_NETA() * config.get_NX() * config.get_NY()];
+	}
 }
 
 // Interfaces of T1 and T2
@@ -78,6 +98,26 @@ double& Event:: T2n (int64_t nx, int64_t ny){return (T2n_ptr)[ NY*nx + ny];}
 
 double Event::T1(int64_t nx, int64_t ny){return  T1p (nx,ny)+T1n (nx,ny); }
 double Event::T2(int64_t nx, int64_t ny){return  T2p (nx,ny)+T2n (nx,ny); }
+
+
+////////// average event interface 
+
+const double& Event::EgAvg (int64_t ieta, int64_t nx, int64_t ny) const {return (EgAvg_ptr)[ NETA*(NY*nx + ny)+ieta];}
+double& Event:: EgAvg (int64_t ieta, int64_t nx, int64_t ny){return (EgAvg_ptr)[ NETA*(NY*nx + ny)+ieta];}
+
+const double& Event::EqAvg (int64_t ieta, int64_t nx, int64_t ny) const {return (EqAvg_ptr)[ NETA*(NY*nx + ny)+ieta];}
+double& Event:: EqAvg (int64_t ieta, int64_t nx, int64_t ny){return (EqAvg_ptr)[ NETA*(NY*nx + ny)+ieta];}
+
+const double& Event::nuAvg (int64_t ieta, int64_t nx, int64_t ny) const {return (nuAvg_ptr)[ NETA*(NY*nx + ny)+ieta];}
+double& Event:: nuAvg (int64_t ieta, int64_t nx, int64_t ny){return (nuAvg_ptr)[ NETA*(NY*nx + ny)+ieta];}
+
+const double& Event::ndAvg (int64_t ieta, int64_t nx, int64_t ny) const {return (ndAvg_ptr)[ NETA*(NY*nx + ny)+ieta];}
+double& Event:: ndAvg (int64_t ieta, int64_t nx, int64_t ny){return (ndAvg_ptr)[ NETA*(NY*nx + ny)+ieta];}
+
+const double& Event::nsAvg (int64_t ieta, int64_t nx, int64_t ny) const {return (nsAvg_ptr)[ NETA*(NY*nx + ny)+ieta];}
+double& Event:: nsAvg (int64_t ieta, int64_t nx, int64_t ny){return (nsAvg_ptr)[ NETA*(NY*nx + ny)+ieta];}
+
+////////////////////////////////
 
 // Evaluation
 // Functions
@@ -112,7 +152,7 @@ void Event::NewEvent(int EventID_in){
 		A1.shift_nucleus_by_impact(b1[0],b1[1]);
 		A2.shift_nucleus_by_impact(b2[0],b2[1]);
 
-		#if OPTICAL==0
+		#if OPTICAL==1
 		if(config.get_Verbose()){std::cout<< "    Running for impact parameter ( bx = " << b1[0]-b2[0] << " , by = " << b1[1]-b2[1] << ")"<<std::endl ;}
 		is_event_valid=true;
 		for (size_t ix = 0; ix < config.get_NX(); ix++) {
@@ -126,9 +166,10 @@ void Event::NewEvent(int EventID_in){
 			}
 		}
 		MakeGlobalQuantities();
+		bool is_charge_output= config.is_format("EMoments") || config.is_format("NMoments") || config.is_format("Charges");
+		if (is_charge_output){MakeChargeOutput();}
 
-		#elif OPTICAL==1
-
+		#elif OPTICAL==0
 
 		CheckParticipants(&A1,&A2);
 
@@ -158,7 +199,10 @@ void Event::NewEvent(int EventID_in){
 
 			MakeGlobalQuantities();
 			bool is_charge_output= config.is_format("EMoments") || config.is_format("NMoments") || config.is_format("Charges");
-			if (is_charge_output){MakeChargeOutput();}
+			if (is_charge_output){
+				if(config.is_boost_invariant() ) {MakeChargeOutputMidrapidity();}
+				else{MakeChargeOutput();}
+			}
 		}
 		#endif
 	}
@@ -178,6 +222,11 @@ void Event::MakeEventByEvent(){
 		for (size_t ev = ev0; ev < config.get_NEvents(); ev++) {NewEvent(get_ID(ev,config.get_NEvents()));}
 	}
 	else{std::cerr<< "[ Error::Event ]: Initial event ID="<< ev0 << " larger than Nevents in config file. Exiting."<<std::endl;}
+	
+	if(config.print_avg_event()>0){
+		MakeGlobalQuantities_AverageEvent();
+		MakeChargeOutput_AverageEvent();
+	}
 }
 
 
@@ -341,9 +390,17 @@ void Event::MakeGlobalQuantities(){
 				nd_t=ChargeMaker->d_density(eta_t, t1p_t, t1n_t, t2p_t, t2n_t) ;
 				ns_t=ChargeMaker->s_density(eta_t, t1_t, t2_t) ;
 
+				if(config.print_avg_event()>0)
+				{
+					EgAvg (ieta, ix, iy)+=eg_t/config.get_NEvents();
+					EqAvg (ieta, ix, iy)+=eq_t/config.get_NEvents();
+					nuAvg (ieta, ix, iy)+=nu_t/config.get_NEvents();
+					ndAvg (ieta, ix, iy)+=nd_t/config.get_NEvents();
+					nsAvg (ieta, ix, iy)+=ns_t/config.get_NEvents();
+				}
+
 				x_cm_unnorm[ieta] += cell_trans_volume * x_t * (eg_t+eq_t);
 				y_cm_unnorm[ieta] += cell_trans_volume * y_t * (eg_t+eq_t);
-
 
 				dEgdeta[ieta]+= cell_trans_volume*(eg_t);
 				dEqdeta[ieta]+= cell_trans_volume*(eq_t);
@@ -446,7 +503,6 @@ void Event::MakeGlobalQuantities(){
 		std::cout<<  "\t d: " << dnddeta[izero]<< "\t s: " << dnsdeta[izero]<<std::endl;
 		std::cout << "    Q = " << total_q_event<< "\tB = " << total_B_event <<std::endl ;
 		std::cout << "\nGlobal CoM coordinates:  ( x = " << x_cm_global << " ,y = " << y_cm_global<< ")"<<std::endl ;
-
 	}
 
 	global_f.close();
@@ -528,6 +584,9 @@ void Event::MakeChargeOutput(){
 				nd_t=ChargeMaker->d_density(eta_t, t1p_t, t1n_t, t2p_t, t2n_t) ;
 				ns_t=ChargeMaker->s_density(eta_t, t1_t, t2_t) ;
 
+				
+
+
 				double r_t = sqrt(x_t*x_t + y_t*y_t);
 				double phi_t = atan2(y_t,x_t);
 				if(config.is_format("EMoments")){
@@ -604,6 +663,168 @@ void Event::MakeChargeOutput(){
 	if(config.get_Verbose()){printProgress(1);}
 
 }
+
+
+void Event::MakeChargeOutputMidrapidity(){
+	std::ofstream charges_f; std::ostringstream charges_name;
+	std::ofstream e_moments_f; std::ostringstream e_moments_name;
+	std::ofstream nu_moments_f; std::ostringstream nu_moments_name;
+	std::ofstream nd_moments_f; std::ostringstream nd_moments_name;
+
+	if(config.is_format("Charges")){
+		charges_name << OUTPATH <<"/Event_"<<EventID<< "_charges.dat" ;
+		charges_f.open(charges_name.str());
+	}
+	
+	if(config.is_format("EMoments")){
+		e_moments_name << OUTPATH <<"/EnergyMoments.dat" ;
+		if(EventID==0){ 
+			e_moments_f.open(e_moments_name.str());
+			e_moments_f<< "# Moment Output at y=0"<< std::endl;
+		}
+		else{e_moments_f.open(e_moments_name.str(),std::ofstream::app);}
+	}
+
+	if(config.is_format("NMoments")){
+		nu_moments_name << OUTPATH <<"/NuMoments.dat" ;
+		if(EventID==0){ 
+			nu_moments_f.open(nu_moments_name.str());
+			nu_moments_f<< "# Moment Output at y=0"<< std::endl;
+		}
+		else{nu_moments_f.open(nu_moments_name.str(),std::ofstream::app);}
+
+		nd_moments_name << OUTPATH <<"/NdMoments.dat" ;
+		if(EventID==0){ 
+			nd_moments_f.open(nd_moments_name.str());
+			nd_moments_f<< "# Moment Output at y=0"<< std::endl;
+		}
+		else{nd_moments_f.open(nd_moments_name.str(),std::ofstream::app);}
+	}
+
+	double eg_t,eq_t,nu_t,nd_t,ns_t;
+	double t1p_t,t1n_t,t2p_t,t2n_t;
+	double t1_t,t2_t;
+
+	double eta_t =0.0;
+
+
+	if(config.get_Verbose()){std::cout<< "\nWriting out -midrapidity- charges and moments for Event " << EventID <<std::endl;}
+	double lattice_sum_dint23dy = 0.;
+
+	std::vector<double> lattice_sum_eg(n_max+1, 0.0);
+	std::vector<double> lattice_sum_eq(n_max+1, 0.0);
+
+	std::vector<double> lattice_sum_eg_cos(n_max+1, 0.0);
+	std::vector<double> lattice_sum_eq_cos(n_max+1, 0.0);
+
+	std::vector<double> lattice_sum_eg_sin(n_max+1, 0.0);
+	std::vector<double> lattice_sum_eq_sin(n_max+1, 0.0);
+
+	std::vector<double> lattice_sum_nu(n_max+1, 0.0);
+	std::vector<double> lattice_sum_nd(n_max+1, 0.0);
+
+	std::vector<double> lattice_sum_nu_cos(n_max+1, 0.0);
+	std::vector<double> lattice_sum_nd_cos(n_max+1, 0.0);
+
+	std::vector<double> lattice_sum_nu_sin(n_max+1, 0.0);
+	std::vector<double> lattice_sum_nd_sin(n_max+1, 0.0);
+
+
+	for (size_t ix = 0; ix < config.get_NX(); ix++) {
+		for (size_t iy = 0; iy < config.get_NY(); iy++) {
+
+			double x_t= get_x(ix)-x_cm_global;
+			double y_t= get_y(iy)-y_cm_global;
+
+			t1p_t=T1p(ix,iy);
+			t1n_t=T1n(ix,iy);
+			t2p_t=T2p(ix,iy);
+			t2n_t=T2n(ix,iy);
+			t1_t = t1p_t+t1n_t;
+			t2_t = t2p_t+t2n_t;
+
+
+			eg_t=ChargeMaker->gluon_energy(eta_t, t1_t, t2_t) * config.get_KFactor()  ;
+			eq_t=ChargeMaker->quark_energy(eta_t, t1_t, t2_t) ;
+			nu_t=ChargeMaker->u_density(eta_t, t1p_t, t1n_t, t2p_t, t2n_t) ;
+			nd_t=ChargeMaker->d_density(eta_t, t1p_t, t1n_t, t2p_t, t2n_t) ;
+			ns_t=ChargeMaker->s_density(eta_t, t1_t, t2_t) ;
+
+			
+
+
+			double r_t = sqrt(x_t*x_t + y_t*y_t);
+			double phi_t = atan2(y_t,x_t);
+			if(config.is_format("EMoments")){
+				lattice_sum_dint23dy +=  cell_trans_volume* gen_pars::GeV2_to_fmm2*pow( gen_pars::fmm2_to_GeV2 * (eg_t + eq_t), 2./3.);
+			}	
+
+			for (int j = 0; j <= n_max; j++)
+			{
+				double jj = (double) j;
+				if(config.is_format("EMoments")){
+					lattice_sum_eg[j] += cell_trans_volume*pow(r_t,jj) * eg_t;
+					lattice_sum_eq[j] += cell_trans_volume*pow(r_t,jj) * eq_t;
+					//
+					lattice_sum_eg_cos[j] += cell_trans_volume*pow(r_t,jj) * cos(jj*phi_t) * eg_t ;
+					lattice_sum_eq_cos[j] += cell_trans_volume*pow(r_t,jj) * cos(jj*phi_t) * eq_t;
+
+					lattice_sum_eg_sin[j] += cell_trans_volume*pow(r_t,jj) * sin(jj*phi_t) * eg_t;
+					lattice_sum_eq_sin[j] += cell_trans_volume*pow(r_t,jj) * sin(jj*phi_t) * eq_t;
+				}
+				if(config.is_format("NMoments")){
+					lattice_sum_nu[j] += cell_trans_volume*pow(r_t,jj) * nu_t;
+					lattice_sum_nd[j] += cell_trans_volume*pow(r_t,jj) * nd_t;
+					//
+					lattice_sum_nu_cos[j] += cell_trans_volume*pow(r_t,jj) * cos(jj*phi_t) * nu_t ;
+					lattice_sum_nd_cos[j] += cell_trans_volume*pow(r_t,jj) * cos(jj*phi_t) * nd_t;
+
+					lattice_sum_nu_sin[j] += cell_trans_volume*pow(r_t,jj) * sin(jj*phi_t) * nu_t;
+					lattice_sum_nd_sin[j] += cell_trans_volume*pow(r_t,jj) * sin(jj*phi_t) * nd_t;
+				}
+			}
+
+			if(config.is_format("Charges")){
+				charges_f<< eta_t <<"\t"<< x_t <<"\t"<< y_t <<"\t"<< eg_t  <<"\t"<< eq_t<<"\t"<< nu_t <<"\t"<< nd_t<<"\t"<< ns_t <<std::endl;
+			}
+		}
+	}
+	if(config.is_format("EMoments")){e_moments_f << EventID << "\t"<< lattice_sum_dint23dy ;}
+	if(config.is_format("NMoments")){
+		nu_moments_f << EventID;
+		nd_moments_f << EventID;
+	}	
+
+	for (size_t j = 0; j <= n_max; j++) {
+		if(config.is_format("EMoments")){
+			e_moments_f << "\t" << lattice_sum_eg[j]<< "\t" <<lattice_sum_eq[j];
+			e_moments_f << "\t" << lattice_sum_eg_cos[j]<< "\t" <<lattice_sum_eq_cos[j];
+			e_moments_f << "\t" << lattice_sum_eg_sin[j]<< "\t" <<lattice_sum_eq_sin[j];
+		}
+		if(config.is_format("NMoments")){
+			nu_moments_f << "\t" << lattice_sum_nu[j]<< "\t" <<lattice_sum_nu_cos[j]<< "\t" << lattice_sum_nu_sin[j];
+			nd_moments_f << "\t" << lattice_sum_nd[j]<< "\t" <<lattice_sum_nd_cos[j]<< "\t" << lattice_sum_nd_sin[j];
+		}
+	}
+	if(config.is_format("EMoments")){e_moments_f << std::endl;}
+	if(config.is_format("NMoments")){
+		nu_moments_f << std::endl;
+		nd_moments_f << std::endl;
+	}
+
+	if(config.is_format("EMoments")){e_moments_f.close();}
+	if(config.is_format("EMoments")){
+		nu_moments_f.close();
+		nd_moments_f.close();
+	}
+
+	if(config.is_format("Charges")){charges_f.close();}
+
+	if(config.get_Verbose()){printProgress(1);}
+
+}
+
+
 
 void Event::MakeChargeOutput_Transverse(double eta){
 
@@ -804,4 +1025,349 @@ void Event::print_glauber_data_to_file(Nucleus * N1,Nucleus * N2){
 
 
 	global_f.close();
+}
+
+void Event::InitializeAverageEvent(){
+	for (size_t ieta = 0; ieta < config.get_NETA(); ieta++) {
+		for (size_t ix = 0; ix < config.get_NX(); ix++) {
+			for (size_t iy = 0; iy < config.get_NY(); iy++) {
+				EgAvg (ieta, ix, iy)=0.0;
+				EqAvg (ieta, ix, iy)=0.0;
+				nuAvg (ieta, ix, iy)=0.0;
+				ndAvg (ieta, ix, iy)=0.0;
+				nsAvg (ieta, ix, iy)=0.0;
+			}
+		}
+	}	
+
+}
+
+
+
+void Event::MakeGlobalQuantities_AverageEvent(){
+
+	std::ofstream global_f;
+	std::ostringstream global_name;
+	global_name << OUTPATH <<"/AverageEvent_global.dat" ;
+	global_f.open(global_name.str(), std::ios_base::app);
+
+	double eg_t,eq_t,nu_t,nd_t,ns_t;
+	double t1p_t,t1n_t,t2p_t,t2n_t;
+	double t1_t,t2_t;
+
+	double total_energy_event_q=0;
+	double total_energy_event_g=0;
+
+	double total_u_event=0;
+	double total_d_event=0;
+	double total_s_event=0;
+	double total_energy_event,total_q_event,total_B_event;
+
+	x_cm.assign(config.get_NETA(),0.0);
+	y_cm.assign(config.get_NETA(),0.0);
+	std::vector<double> x_cm_unnorm(config.get_NETA(),0.0);
+	std::vector<double> y_cm_unnorm(config.get_NETA(),0.0);
+
+	std::vector<double> egtau0_2o3_midrap(config.get_NETA(),0.0);
+	std::vector<double> eqtau0_2o3_midrap(config.get_NETA(),0.0);
+	std::vector<double> etottau0_2o3_midrap(config.get_NETA(),0.0);
+
+	int izero = int( -config.get_ETAMIN()/config.get_dETA());
+
+	dEdeta.assign(config.get_NETA(),0.0);
+	dEgdeta.assign(config.get_NETA(),0.0);
+	dEqdeta.assign(config.get_NETA(),0.0);
+	dnudeta.assign(config.get_NETA(),0.0);
+	dnddeta.assign(config.get_NETA(),0.0);
+	dnsdeta.assign(config.get_NETA(),0.0);
+
+	double x_cm_global_unnorm=0.;
+	double y_cm_global_unnorm=0.;
+ 	x_cm_global=0.;
+	y_cm_global=0.;
+
+	if(config.get_Verbose()){std::cout<< "\n Making global observables and observables for Average Event "<<std::endl;}
+
+	for (size_t ieta = 0; ieta < config.get_NETA(); ieta++) {
+		double eta_t = ieta*config.get_dETA() + config.get_ETAMIN();
+		for (size_t ix = 0; ix < config.get_NX(); ix++) {
+			for (size_t iy = 0; iy < config.get_NY(); iy++) {
+
+				double x_t= get_x(ix);
+				double y_t= get_y(iy);
+
+				t1p_t=T1p(ix,iy);
+				t1n_t=T1n(ix,iy);
+				t2p_t=T2p(ix,iy);
+				t2n_t=T2n(ix,iy);
+				t1_t = t1p_t+t1n_t;
+				t2_t = t2p_t+t2n_t;
+
+				eg_t= EgAvg (ieta, ix, iy);
+				eq_t= EqAvg (ieta, ix, iy);
+				nu_t= nuAvg (ieta, ix, iy);
+				nd_t= ndAvg (ieta, ix, iy);
+				ns_t= nsAvg (ieta, ix, iy);
+
+				x_cm_unnorm[ieta] += cell_trans_volume * x_t * (eg_t+eq_t);
+				y_cm_unnorm[ieta] += cell_trans_volume * y_t * (eg_t+eq_t);
+
+				dEgdeta[ieta]+= cell_trans_volume*(eg_t);
+				dEqdeta[ieta]+= cell_trans_volume*(eq_t);
+				dEdeta[ieta]+= cell_trans_volume*(eg_t+eq_t);
+
+
+				dnudeta[ieta]+= cell_trans_volume*nu_t;
+				dnddeta[ieta]+= cell_trans_volume*nd_t;
+				dnsdeta[ieta]+= cell_trans_volume*ns_t;
+
+				total_energy_event_g += config.get_dETA() * cell_trans_volume * eg_t;
+				total_energy_event_q += config.get_dETA() * cell_trans_volume * eq_t;
+
+				egtau0_2o3_midrap[ieta] += cell_trans_volume * gen_pars::GeV2_to_fmm2 * pow(gen_pars::fmm2_to_GeV2*eg_t,2/3.);//cell_trans_volume* gen_pars::GeV2_to_fmm2*pow( gen_pars::fmm2_to_GeV2 * (eg_t + eq_t), 2./3.);
+				eqtau0_2o3_midrap[ieta] += cell_trans_volume * gen_pars::GeV2_to_fmm2 * pow(gen_pars::fmm2_to_GeV2*eq_t,2/3.);
+				etottau0_2o3_midrap[ieta] += cell_trans_volume * gen_pars::GeV2_to_fmm2 * pow( gen_pars::fmm2_to_GeV2*(eg_t+eq_t),2/3.);
+
+
+			}
+		}
+
+		if(dEdeta[ieta]==0){
+			x_cm[ieta]=0;
+			y_cm[ieta]=0;
+		}
+		else{
+			x_cm[ieta] += x_cm_unnorm[ieta]/dEdeta[ieta];
+			y_cm[ieta] += y_cm_unnorm[ieta]/dEdeta[ieta];
+		}
+
+  
+
+		x_cm_global_unnorm += config.get_dETA() *x_cm_unnorm[ieta] ;
+		y_cm_global_unnorm += config.get_dETA() *y_cm_unnorm[ieta] ;
+
+		total_u_event += config.get_dETA() * dnudeta[ieta];
+		total_d_event += config.get_dETA() * dnddeta[ieta];
+		total_s_event += config.get_dETA() * dnsdeta[ieta];
+
+		if(config.get_Verbose()){
+			double percentage_done=double(ieta)/double(config.get_NETA());
+			printProgress(percentage_done);
+		}
+	}
+
+	if(config.get_Verbose()){printProgress(1);}
+
+	total_energy_event=total_energy_event_q+total_energy_event_g;
+
+	if(total_energy_event==0){
+		x_cm_global=0;
+		y_cm_global=0;
+	}
+	else{
+		x_cm_global=x_cm_global_unnorm/total_energy_event;
+		y_cm_global=y_cm_global_unnorm/total_energy_event;
+	}
+
+	total_q_event= (2*total_u_event-total_d_event)/3;
+	total_B_event= (total_u_event+total_d_event)/3;
+
+	global_f<<  "E_g\t" << total_energy_event_g<<std::endl;
+	global_f<<  "E_q\t" << total_energy_event_q<<std::endl;
+	global_f<<  "E_tot\t" << total_energy_event<<std::endl;
+
+	global_f<<  "dEg_deta\t" << dEgdeta[izero]<<std::endl;
+	global_f<<  "dEq_deta\t" << dEqdeta[izero]<<std::endl;
+	global_f<<  "dE_deta\t" << dEdeta[izero]<<std::endl;
+
+	global_f<<  "Int(egtau)2/3\t" << egtau0_2o3_midrap[izero] <<std::endl;
+	global_f<<  "Int(eqtau)2/3\t" << eqtau0_2o3_midrap[izero]<<std::endl;
+	global_f<<  "Int(egtau+eqtau)2/3\t" << etottau0_2o3_midrap[izero]<<std::endl;
+
+	global_f<<  "N_u\t" << total_u_event<<std::endl;
+	global_f<<  "N_d\t" << total_d_event<<std::endl;
+	global_f<<  "N_s\t" << total_s_event<<std::endl;
+
+	global_f<<  "dNu_deta(eta=0)\t" << dnudeta[izero]<<std::endl;
+	global_f<<  "dNd_deta(eta=0)\t" << dnddeta[izero]<<std::endl;
+	global_f<<  "dNs_deta(eta=0)\t" << dnsdeta[izero]<<std::endl;
+
+	global_f<<  "Q\t" << total_q_event<<std::endl;
+	global_f<<  "B\t" << total_B_event<<std::endl;
+
+	global_f<<  "dQ_deta(eta=0)\t" << (2*dnudeta[izero]-dnddeta[izero] )/3.<<std::endl;
+	global_f<<  "dB_deta(eta=0)\t" << (dnudeta[izero]+dnddeta[izero] )/3.<<std::endl;
+
+	global_f<<  "x_cm_global\t" << x_cm_global<<std::endl;
+	global_f<<  "y_cm_global\t" << y_cm_global<<std::endl;
+
+	global_f<<  "x_cm_mid\t" << x_cm[izero]<<std::endl;
+	global_f<<  "y_cm_mid\t" << y_cm[izero]<<std::endl;
+
+
+	if(config.get_Verbose()){
+		std::cout << "\n\n    E_g = " << total_energy_event_g << "\tE_q = " << total_energy_event_q << "\tE_tot = " << total_energy_event<<std::endl ;
+		std::cout<<  "    dE_deta = " << dEdeta[izero]<<  "\t with \tdEg_deta = " << dEgdeta[izero]<<  "    and    dEq_deta = " << dEqdeta[izero]<<std::endl;
+		std::cout << "    N_u = " << total_u_event<< "\tN_d = " << total_d_event << "\tN_s = " << total_s_event <<std::endl ;
+		std::cout<<  "    dN_i_deta(eta=0)     u: " << dnudeta[izero];
+		std::cout<<  "\t d: " << dnddeta[izero]<< "\t s: " << dnsdeta[izero]<<std::endl;
+		std::cout << "    Q = " << total_q_event<< "\tB = " << total_B_event <<std::endl ;
+		std::cout << "\nGlobal CoM coordinates:  ( x = " << x_cm_global << " ,y = " << y_cm_global<< ")"<<std::endl ;
+	}
+
+	global_f.close();
+
+}
+
+
+void Event::MakeChargeOutput_AverageEvent(){
+	std::ofstream charges_f; std::ostringstream charges_name;
+	std::ofstream e_moments_f; std::ostringstream e_moments_name;
+	std::ofstream nu_moments_f; std::ostringstream nu_moments_name;
+	std::ofstream nd_moments_f; std::ostringstream nd_moments_name;
+
+	if(config.print_avg_event()>1){
+		charges_name << OUTPATH <<"/AverageEvent_Event_charges.dat" ;
+		charges_f.open(charges_name.str());
+	}
+	
+	if(config.print_avg_event()>0){
+		e_moments_name << OUTPATH <<"/AverageEvent_EnergyMoments.dat" ;
+		e_moments_f.open(e_moments_name.str());
+	}
+
+	if(config.print_avg_event()>0){
+		nu_moments_name << OUTPATH <<"/AverageEvent_NuMoments.dat" ;
+		nu_moments_f.open(nu_moments_name.str());
+
+		nd_moments_name << OUTPATH <<"/AverageEvent_NdMoments.dat" ;
+		nd_moments_f.open(nd_moments_name.str());
+	}
+
+	double eg_t,eq_t,nu_t,nd_t,ns_t;
+	double t1p_t,t1n_t,t2p_t,t2n_t;
+	double t1_t,t2_t;
+
+
+	if(config.get_Verbose()){std::cout<< "\nWriting out charges and moments for Average Event "<<std::endl;}
+
+	for (size_t ieta = 0; ieta < config.get_NETA(); ieta++) {
+		double eta_t = ieta*config.get_dETA() + config.get_ETAMIN();
+
+		double lattice_sum_dint23dy = 0.;
+
+		std::vector<double> lattice_sum_eg(n_max+1, 0.0);
+		std::vector<double> lattice_sum_eq(n_max+1, 0.0);
+
+		std::vector<double> lattice_sum_eg_cos(n_max+1, 0.0);
+		std::vector<double> lattice_sum_eq_cos(n_max+1, 0.0);
+
+		std::vector<double> lattice_sum_eg_sin(n_max+1, 0.0);
+		std::vector<double> lattice_sum_eq_sin(n_max+1, 0.0);
+
+		std::vector<double> lattice_sum_nu(n_max+1, 0.0);
+		std::vector<double> lattice_sum_nd(n_max+1, 0.0);
+
+		std::vector<double> lattice_sum_nu_cos(n_max+1, 0.0);
+		std::vector<double> lattice_sum_nd_cos(n_max+1, 0.0);
+
+		std::vector<double> lattice_sum_nu_sin(n_max+1, 0.0);
+		std::vector<double> lattice_sum_nd_sin(n_max+1, 0.0);
+
+
+		for (size_t ix = 0; ix < config.get_NX(); ix++) {
+			for (size_t iy = 0; iy < config.get_NY(); iy++) {
+
+				double x_t= get_x(ix)-x_cm_global;
+				double y_t= get_y(iy)-y_cm_global;
+
+				t1p_t=T1p(ix,iy);
+				t1n_t=T1n(ix,iy);
+				t2p_t=T2p(ix,iy);
+				t2n_t=T2n(ix,iy);
+				t1_t = t1p_t+t1n_t;
+				t2_t = t2p_t+t2n_t;
+
+				eg_t= EgAvg (ieta, ix, iy);
+				eq_t= EqAvg (ieta, ix, iy);
+				nu_t= nuAvg (ieta, ix, iy);
+				nd_t= ndAvg (ieta, ix, iy);
+				ns_t= nsAvg (ieta, ix, iy);
+
+
+				double r_t = sqrt(x_t*x_t + y_t*y_t);
+				double phi_t = atan2(y_t,x_t);
+				if(config.print_avg_event()>0){
+					lattice_sum_dint23dy +=  cell_trans_volume* gen_pars::GeV2_to_fmm2*pow( gen_pars::fmm2_to_GeV2 * (eg_t + eq_t), 2./3.);
+				}	
+
+				for (int j = 0; j <= n_max; j++)
+				{
+					double jj = (double) j;
+					if(config.print_avg_event()>0){
+						lattice_sum_eg[j] += cell_trans_volume*pow(r_t,jj) * eg_t;
+						lattice_sum_eq[j] += cell_trans_volume*pow(r_t,jj) * eq_t;
+						//
+						lattice_sum_eg_cos[j] += cell_trans_volume*pow(r_t,jj) * cos(jj*phi_t) * eg_t ;
+						lattice_sum_eq_cos[j] += cell_trans_volume*pow(r_t,jj) * cos(jj*phi_t) * eq_t;
+
+						lattice_sum_eg_sin[j] += cell_trans_volume*pow(r_t,jj) * sin(jj*phi_t) * eg_t;
+						lattice_sum_eq_sin[j] += cell_trans_volume*pow(r_t,jj) * sin(jj*phi_t) * eq_t;
+					}
+					if(config.print_avg_event()>0){
+						lattice_sum_nu[j] += cell_trans_volume*pow(r_t,jj) * nu_t;
+						lattice_sum_nd[j] += cell_trans_volume*pow(r_t,jj) * nd_t;
+						//
+						lattice_sum_nu_cos[j] += cell_trans_volume*pow(r_t,jj) * cos(jj*phi_t) * nu_t ;
+						lattice_sum_nd_cos[j] += cell_trans_volume*pow(r_t,jj) * cos(jj*phi_t) * nd_t;
+
+						lattice_sum_nu_sin[j] += cell_trans_volume*pow(r_t,jj) * sin(jj*phi_t) * nu_t;
+						lattice_sum_nd_sin[j] += cell_trans_volume*pow(r_t,jj) * sin(jj*phi_t) * nd_t;
+					}
+				}
+
+				if(config.print_avg_event()>1){
+					charges_f<< eta_t <<"\t"<< x_t <<"\t"<< y_t <<"\t"<< eg_t  <<"\t"<< eq_t<<"\t"<< nu_t <<"\t"<< nd_t<<"\t"<< ns_t <<std::endl;
+				}
+			}
+		}
+		if(config.print_avg_event()>0){e_moments_f << eta_t << "\t"<< lattice_sum_dint23dy ;}
+		if(config.print_avg_event()>0){
+			nu_moments_f << eta_t;
+			nd_moments_f << eta_t;
+		}	
+
+		for (size_t j = 0; j <= n_max; j++) {
+			if(config.print_avg_event()>0){
+				e_moments_f << "\t" << lattice_sum_eg[j]<< "\t" <<lattice_sum_eq[j];
+				e_moments_f << "\t" << lattice_sum_eg_cos[j]<< "\t" <<lattice_sum_eq_cos[j];
+				e_moments_f << "\t" << lattice_sum_eg_sin[j]<< "\t" <<lattice_sum_eq_sin[j];
+			}
+			if(config.print_avg_event()>0){
+				nu_moments_f << "\t" << lattice_sum_nu[j]<< "\t" <<lattice_sum_nu_cos[j]<< "\t" << lattice_sum_nu_sin[j];
+				nd_moments_f << "\t" << lattice_sum_nd[j]<< "\t" <<lattice_sum_nd_cos[j]<< "\t" << lattice_sum_nd_sin[j];
+			}
+		}
+		if(config.print_avg_event()>0){e_moments_f << std::endl;}
+		if(config.print_avg_event()>0){
+			nu_moments_f << std::endl;
+			nd_moments_f << std::endl;
+		}
+
+		if(config.get_Verbose()){
+			double percentage_done=double(ieta)/double(config.get_NETA());
+			printProgress(percentage_done);
+		}
+	}
+
+	if(config.print_avg_event()>0){e_moments_f.close();}
+	if(config.print_avg_event()>0){
+		nu_moments_f.close();
+		nd_moments_f.close();
+	}
+
+	if(config.print_avg_event()>1){charges_f.close();}
+
+	if(config.get_Verbose()){printProgress(1);}
+
 }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1053,7 +1053,7 @@ void Event::MakeGlobalQuantities_AverageEvent(){
 
 	double eg_t,eq_t,nu_t,nd_t,ns_t;
 	double t1p_t,t1n_t,t2p_t,t2n_t;
-	double t1_t,t2_t;
+	// double t1_t,t2_t;
 
 	double total_energy_event_q=0;
 	double total_energy_event_g=0;
@@ -1089,7 +1089,7 @@ void Event::MakeGlobalQuantities_AverageEvent(){
 	if(config.get_Verbose()){std::cout<< "\n Making global observables and observables for Average Event "<<std::endl;}
 
 	for (int ieta = 0; ieta < config.get_NETA(); ieta++) {
-		double eta_t = ieta*config.get_dETA() + config.get_ETAMIN();
+		// double eta_t = ieta*config.get_dETA() + config.get_ETAMIN();
 		for (int ix = 0; ix < config.get_NX(); ix++) {
 			for (int iy = 0; iy < config.get_NY(); iy++) {
 
@@ -1100,8 +1100,8 @@ void Event::MakeGlobalQuantities_AverageEvent(){
 				t1n_t=T1n(ix,iy);
 				t2p_t=T2p(ix,iy);
 				t2n_t=T2n(ix,iy);
-				t1_t = t1p_t+t1n_t;
-				t2_t = t2p_t+t2n_t;
+				// t1_t = t1p_t+t1n_t;
+				// t2_t = t2p_t+t2n_t;
 
 				eg_t= EgAvg (ieta, ix, iy);
 				eq_t= EqAvg (ieta, ix, iy);
@@ -1246,7 +1246,7 @@ void Event::MakeChargeOutput_AverageEvent(){
 
 	double eg_t,eq_t,nu_t,nd_t,ns_t;
 	double t1p_t,t1n_t,t2p_t,t2n_t;
-	double t1_t,t2_t;
+	// double t1_t,t2_t;
 
 
 	if(config.get_Verbose()){std::cout<< "\nWriting out charges and moments for Average Event "<<std::endl;}
@@ -1285,8 +1285,8 @@ void Event::MakeChargeOutput_AverageEvent(){
 				t1n_t=T1n(ix,iy);
 				t2p_t=T2p(ix,iy);
 				t2n_t=T2n(ix,iy);
-				t1_t = t1p_t+t1n_t;
-				t2_t = t2p_t+t2n_t;
+				// t1_t = t1p_t+t1n_t;
+				// t2_t = t2p_t+t2n_t;
 
 				eg_t= EgAvg (ieta, ix, iy);
 				eq_t= EqAvg (ieta, ix, iy);

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -155,8 +155,8 @@ void Event::NewEvent(int EventID_in){
 		#if OPTICAL==1
 		if(config.get_Verbose()){std::cout<< "    Running for impact parameter ( bx = " << b1[0]-b2[0] << " , by = " << b1[1]-b2[1] << ")"<<std::endl ;}
 		is_event_valid=true;
-		for (size_t ix = 0; ix < config.get_NX(); ix++) {
-			for (size_t iy = 0; iy < config.get_NY(); iy++) {
+		for (int ix = 0; ix < config.get_NX(); ix++) {
+			for (int iy = 0; iy < config.get_NY(); iy++) {
 				double x_t= get_x(ix);
 				double y_t= get_y(iy);
 				T1p (ix,iy)= A1.get_Z()*A1.nuclear_thickness_optical(x_t-b1[0], y_t-b1[1]);
@@ -185,8 +185,8 @@ void Event::NewEvent(int EventID_in){
 
 			if(config.get_Verbose()){std::cout<<"    Nucleon Positions written out\n";}
 
-			for (size_t ix = 0; ix < config.get_NX(); ix++) {
-				for (size_t iy = 0; iy < config.get_NY(); iy++) {
+			for (int ix = 0; ix < config.get_NX(); ix++) {
+				for (int iy = 0; iy < config.get_NY(); iy++) {
 					double x_t= get_x(ix);
 					double y_t= get_y(iy);
 					T1p (ix,iy)= A1.GetThickness_p(x_t,y_t, config.get_BG());
@@ -219,7 +219,7 @@ void Event::MakeEventByEvent(){
 	/* This function iterates over the number of listed EVENTS */
 	if( ev0 < config.get_NEvents()){
 		std::cerr<< "[ Warning::Event ]: Event generation starting from event # "<< ev0 << std::endl;
-		for (size_t ev = ev0; ev < config.get_NEvents(); ev++) {NewEvent(get_ID(ev,config.get_NEvents()));}
+		for (int ev = ev0; ev < config.get_NEvents(); ev++) {NewEvent(get_ID(ev,config.get_NEvents()));}
 	}
 	else{std::cerr<< "[ Error::Event ]: Initial event ID="<< ev0 << " larger than Nevents in config file. Exiting."<<std::endl;}
 	
@@ -267,7 +267,7 @@ void Event::Initialize_output(){
 		ev0=0;
 		if ( !(fs::create_directories(dirpath))){
 			std::cerr<< "[ Warning::Event ]: Output directory ("<< OUTPATH<< ") already exists!"<< std::endl ;
-			for (size_t iev = 0; iev < config.get_NEvents(); iev++)
+			for (int iev = 0; iev < config.get_NEvents(); iev++)
 			{
 				std::ostringstream filename_t;
 				filename_t << config.get_out_path()<<"/" <<config.get_run_name() << "/global_"<< iev<< ".dat"	;
@@ -312,12 +312,12 @@ void Event::dump_nucleon_pos(Nucleus *A1,Nucleus *A2){
   pos_f.open(posname.str());
 
 	double x_t,y_t,z_t;
-  for (size_t i = 0; i < A1->get_A(); i++) {
+  for (int i = 0; i < A1->get_A(); i++) {
 		A1->get_position_nucleon(i, x_t,y_t,z_t);
 		pos_f<< i <<"\t"<< x_t<<"\t"<< y_t<<"\t"<< z_t<<"\t"<< A1->get_ParticipantStatus(i)<<std::endl;
 	}
 		pos_f<<std::endl;
-	for (size_t i = 0; i < A2->get_A(); i++) {
+	for (int i = 0; i < A2->get_A(); i++) {
 		A2->get_position_nucleon(i, x_t,y_t,z_t);
 		pos_f<< i <<"\t"<< x_t<<"\t"<< y_t<<"\t"<< z_t<<"\t"<< A2->get_ParticipantStatus(i)<<std::endl;
 	}
@@ -369,10 +369,10 @@ void Event::MakeGlobalQuantities(){
 
 	if(config.get_Verbose()){std::cout<< "\n Making global observables and observables for Event " << EventID <<std::endl;}
 
-	for (size_t ieta = 0; ieta < config.get_NETA(); ieta++) {
+	for (int ieta = 0; ieta < config.get_NETA(); ieta++) {
 		double eta_t = ieta*config.get_dETA() + config.get_ETAMIN();
-		for (size_t ix = 0; ix < config.get_NX(); ix++) {
-			for (size_t iy = 0; iy < config.get_NY(); iy++) {
+		for (int ix = 0; ix < config.get_NX(); ix++) {
+			for (int iy = 0; iy < config.get_NY(); iy++) {
 
 				double x_t= get_x(ix);
 				double y_t= get_y(iy);
@@ -540,7 +540,7 @@ void Event::MakeChargeOutput(){
 
 	if(config.get_Verbose()){std::cout<< "\nWriting out charges and moments for Event " << EventID <<std::endl;}
 
-	for (size_t ieta = 0; ieta < config.get_NETA(); ieta++) {
+	for (int ieta = 0; ieta < config.get_NETA(); ieta++) {
 		double eta_t = ieta*config.get_dETA() + config.get_ETAMIN();
 
 		double lattice_sum_dint23dy = 0.;
@@ -564,8 +564,8 @@ void Event::MakeChargeOutput(){
 		std::vector<double> lattice_sum_nd_sin(n_max+1, 0.0);
 
 
-		for (size_t ix = 0; ix < config.get_NX(); ix++) {
-			for (size_t iy = 0; iy < config.get_NY(); iy++) {
+		for (int ix = 0; ix < config.get_NX(); ix++) {
+			for (int iy = 0; iy < config.get_NY(); iy++) {
 
 				double x_t= get_x(ix)-x_cm_global;
 				double y_t= get_y(iy)-y_cm_global;
@@ -629,7 +629,7 @@ void Event::MakeChargeOutput(){
 			nd_moments_f << eta_t;
 		}	
 
-		for (size_t j = 0; j <= n_max; j++) {
+		for (int j = 0; j <= n_max; j++) {
 			if(config.is_format("EMoments")){
 				e_moments_f << "\t" << lattice_sum_eg[j]<< "\t" <<lattice_sum_eq[j];
 				e_moments_f << "\t" << lattice_sum_eg_cos[j]<< "\t" <<lattice_sum_eq_cos[j];
@@ -730,8 +730,8 @@ void Event::MakeChargeOutputMidrapidity(){
 	std::vector<double> lattice_sum_nd_sin(n_max+1, 0.0);
 
 
-	for (size_t ix = 0; ix < config.get_NX(); ix++) {
-		for (size_t iy = 0; iy < config.get_NY(); iy++) {
+	for (int ix = 0; ix < config.get_NX(); ix++) {
+		for (int iy = 0; iy < config.get_NY(); iy++) {
 
 			double x_t= get_x(ix)-x_cm_global;
 			double y_t= get_y(iy)-y_cm_global;
@@ -795,7 +795,7 @@ void Event::MakeChargeOutputMidrapidity(){
 		nd_moments_f << EventID;
 	}	
 
-	for (size_t j = 0; j <= n_max; j++) {
+	for (int j = 0; j <= n_max; j++) {
 		if(config.is_format("EMoments")){
 			e_moments_f << "\t" << lattice_sum_eg[j]<< "\t" <<lattice_sum_eq[j];
 			e_moments_f << "\t" << lattice_sum_eg_cos[j]<< "\t" <<lattice_sum_eq_cos[j];
@@ -837,8 +837,8 @@ void Event::MakeChargeOutput_Transverse(double eta){
 	double t1p_t,t1n_t,t2p_t,t2n_t;
 	double t1_t,t2_t;
 
-	for (size_t ix = 0; ix < config.get_NX(); ix++) {
-		for (size_t iy = 0; iy < config.get_NY(); iy++) {
+	for (int ix = 0; ix < config.get_NX(); ix++) {
+		for (int iy = 0; iy < config.get_NY(); iy++) {
 
 			double x_t= get_x(ix);
 			double y_t= get_y(iy);
@@ -871,8 +871,8 @@ void Event::MakeThicknessOutput(){
 	  chargesname << OUTPATH <<"/Event_"<<EventID<< "_Thickness.dat" ;
 	  charges_f.open(chargesname.str());
 
-		for (size_t ix = 0; ix < config.get_NX(); ix++) {
-			for (size_t iy = 0; iy < config.get_NY(); iy++) {
+		for (int ix = 0; ix < config.get_NX(); ix++) {
+			for (int iy = 0; iy < config.get_NY(); iy++) {
 				double x_t= get_x(ix);
 				double y_t= get_y(iy);
 				charges_f<< x_t <<"\t"<< y_t <<"\t"<< T1p(ix,iy) <<"\t"<< T1n(ix,iy) <<"\t"<< T2p(ix,iy) <<"\t"<< T2n(ix,iy) <<std::endl;
@@ -1028,9 +1028,9 @@ void Event::print_glauber_data_to_file(Nucleus * N1,Nucleus * N2){
 }
 
 void Event::InitializeAverageEvent(){
-	for (size_t ieta = 0; ieta < config.get_NETA(); ieta++) {
-		for (size_t ix = 0; ix < config.get_NX(); ix++) {
-			for (size_t iy = 0; iy < config.get_NY(); iy++) {
+	for (int ieta = 0; ieta < config.get_NETA(); ieta++) {
+		for (int ix = 0; ix < config.get_NX(); ix++) {
+			for (int iy = 0; iy < config.get_NY(); iy++) {
 				EgAvg (ieta, ix, iy)=0.0;
 				EqAvg (ieta, ix, iy)=0.0;
 				nuAvg (ieta, ix, iy)=0.0;
@@ -1088,10 +1088,10 @@ void Event::MakeGlobalQuantities_AverageEvent(){
 
 	if(config.get_Verbose()){std::cout<< "\n Making global observables and observables for Average Event "<<std::endl;}
 
-	for (size_t ieta = 0; ieta < config.get_NETA(); ieta++) {
+	for (int ieta = 0; ieta < config.get_NETA(); ieta++) {
 		double eta_t = ieta*config.get_dETA() + config.get_ETAMIN();
-		for (size_t ix = 0; ix < config.get_NX(); ix++) {
-			for (size_t iy = 0; iy < config.get_NY(); iy++) {
+		for (int ix = 0; ix < config.get_NX(); ix++) {
+			for (int iy = 0; iy < config.get_NY(); iy++) {
 
 				double x_t= get_x(ix);
 				double y_t= get_y(iy);
@@ -1251,7 +1251,7 @@ void Event::MakeChargeOutput_AverageEvent(){
 
 	if(config.get_Verbose()){std::cout<< "\nWriting out charges and moments for Average Event "<<std::endl;}
 
-	for (size_t ieta = 0; ieta < config.get_NETA(); ieta++) {
+	for (int ieta = 0; ieta < config.get_NETA(); ieta++) {
 		double eta_t = ieta*config.get_dETA() + config.get_ETAMIN();
 
 		double lattice_sum_dint23dy = 0.;
@@ -1275,8 +1275,8 @@ void Event::MakeChargeOutput_AverageEvent(){
 		std::vector<double> lattice_sum_nd_sin(n_max+1, 0.0);
 
 
-		for (size_t ix = 0; ix < config.get_NX(); ix++) {
-			for (size_t iy = 0; iy < config.get_NY(); iy++) {
+		for (int ix = 0; ix < config.get_NX(); ix++) {
+			for (int iy = 0; iy < config.get_NY(); iy++) {
 
 				double x_t= get_x(ix)-x_cm_global;
 				double y_t= get_y(iy)-y_cm_global;
@@ -1337,7 +1337,7 @@ void Event::MakeChargeOutput_AverageEvent(){
 			nd_moments_f << eta_t;
 		}	
 
-		for (size_t j = 0; j <= n_max; j++) {
+		for (int j = 0; j <= n_max; j++) {
 			if(config.print_avg_event()>0){
 				e_moments_f << "\t" << lattice_sum_eg[j]<< "\t" <<lattice_sum_eq[j];
 				e_moments_f << "\t" << lattice_sum_eg_cos[j]<< "\t" <<lattice_sum_eq_cos[j];

--- a/src/include/Hankel.h
+++ b/src/include/Hankel.h
@@ -113,9 +113,9 @@ public:
   void Transform(){
     double Fx_t[NPoints];
     double Fk_t[NPoints];
-    for (size_t i = 0; i < NPoints; i++) {Fx_t[i]=Fx.at(i);}
+    for (int i = 0; i < NPoints; i++) {Fx_t[i]=Fx.at(i);}
 		gsl_dht_apply(tf,Fx_t,Fk_t);
-    for (size_t i = 0; i < NPoints; i++) {Fk.at(i)=Fk_t[i];}
+    for (int i = 0; i < NPoints; i++) {Fk.at(i)=Fk_t[i];}
   }
 
   //Auxiliary

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -126,7 +126,7 @@ class Config{
     std::string get_version(){return version;}
     bool is_output_named(){return is_run_renamed;}
     bool is_format(std::string test_format){
-      for (size_t i = 0; i < n_formats; i++){
+      for (int i = 0; i < n_formats; i++){
         if(format[i]==test_format){return true;}
       }
       return false;
@@ -176,7 +176,7 @@ class Config{
     double ModelPars[10];
     int NModelParams;
     // Output
-    size_t n_formats;
+    int n_formats;
     std::string path_to_output;
     std::string run_name;
     bool is_run_renamed=false;

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -131,6 +131,8 @@ class Config{
       }
       return false;
     }
+    int print_avg_event(){return print_avg;}
+    bool is_boost_invariant(){return boost_invariant;}
 
   private:
 
@@ -179,6 +181,9 @@ class Config{
     std::string run_name;
     bool is_run_renamed=false;
     std::string * format;
+    int print_avg=0;
+    bool boost_invariant=false;
+
     // Thickness_Parameters
     double TMax=-1;
     double TMin=-1;

--- a/src/include/event.h
+++ b/src/include/event.h
@@ -117,7 +117,6 @@ class Event{
 
 		int EventID;
 		int PrimalSeed;
-		int EventSeed;
 
 		double sqrtsNN;
 

--- a/src/include/event.h
+++ b/src/include/event.h
@@ -24,6 +24,7 @@ class Event{
 		void sample_bdb_impact(double bmin, double bmax);
 
 		void MakeEventByEvent();
+		void InitializeAverageEvent();
 
 		double uni_nu_rn(){return drand48();}
 
@@ -43,14 +44,36 @@ class Event{
 		double T1(int64_t nx, int64_t ny);
 		double T2(int64_t nx, int64_t ny);
 
+		//AVG EVENT 
+
+		const double& EgAvg (int64_t neta, int64_t nx, int64_t ny) const;
+		double& EgAvg (int64_t neta, int64_t nx, int64_t ny);
+
+		const double& EqAvg (int64_t neta, int64_t nx, int64_t ny) const;
+		double& EqAvg (int64_t neta, int64_t nx, int64_t ny);
+
+		const double& nuAvg (int64_t neta, int64_t nx, int64_t ny) const;
+		double& nuAvg (int64_t neta, int64_t nx, int64_t ny);
+
+		const double& ndAvg (int64_t neta, int64_t nx, int64_t ny) const;
+		double& ndAvg (int64_t neta, int64_t nx, int64_t ny);
+
+		const double& nsAvg (int64_t neta, int64_t nx, int64_t ny) const;
+		double& nsAvg (int64_t neta, int64_t nx, int64_t ny);
+
+
 		// OUTPUT
 		void Initialize_output();
 		void dump_nucleon_pos(Nucleus * A1,Nucleus * A2);
 		void MakeChargeOutput();
 		void MakeGlobalQuantities();
+		void MakeGlobalQuantities_AverageEvent();
+		void MakeChargeOutput_AverageEvent();
 		void MakeThicknessOutput();
 		void MakeChargeOutput_Transverse(double eta);
 		void Make_Event_Output();
+
+		void MakeChargeOutputMidrapidity();
 
 		
 
@@ -89,6 +112,7 @@ class Event{
 
 		int NX;
 		int NY;
+		int NETA;
 		double cell_trans_volume;
 
 		int EventID;
@@ -104,6 +128,12 @@ class Event{
 		double *T1n_ptr;
 		double *T2p_ptr;
 		double *T2n_ptr;
+
+		double * EgAvg_ptr;
+		double * EqAvg_ptr;
+		double * nuAvg_ptr;
+		double * ndAvg_ptr;
+		double * nsAvg_ptr;
 
 		std::vector<double> x_cm;
 		std::vector<double> y_cm;

--- a/src/include/model_ipsat.h
+++ b/src/include/model_ipsat.h
@@ -16,8 +16,7 @@ struct GluonParsIPSat{
 //Dynamical
   double sqrts;
   double y;
-  double qt;
-  double kt;
+  double p_reg;
 
 //Geometrical
   double T1;
@@ -64,6 +63,7 @@ class IPSat{
 		std::string path_to_set;
     int p_set;
     double xscaling;
+    double p_reg;
 
     double S0;
 		double dT;

--- a/src/include/nuclear_data.h
+++ b/src/include/nuclear_data.h
@@ -35,52 +35,52 @@ namespace  NuclearData { ///TO DO, get more elements!
       switch (Z) {
         case 8: // Oxygen 
           if(A==16){
-            if(mode==0){for (size_t i = 0; i < 2; i++) { pars[i]=O_sph[i];} }
+            if(mode==0){for (int i = 0; i < 2; i++) { pars[i]=O_sph[i];} }
             else{std::cerr<< "Error! Non-spherical parametrization not implemented for O-16!" ;exit(EXIT_FAILURE);}
             }
           break;
         case 13:
           if(A==27){
-            if(mode==1){for (size_t i = 0; i < 4; i++) { pars[i]=Al_def[i];} }
+            if(mode==1){for (int i = 0; i < 4; i++) { pars[i]=Al_def[i];} }
             else{std::cerr<< "Error! Non-deformed parametrization not implemented for Al-27!" ;exit(EXIT_FAILURE);}
           }
           break;
         case 18:
           if(A==40){
-            if(mode==0){for (size_t i = 0; i < 2; i++) { pars[i]=Ar_sph[i];} }
+            if(mode==0){for (int i = 0; i < 2; i++) { pars[i]=Ar_sph[i];} }
             else{std::cerr<< "Error! Non-spherical parametrization not implemented for Ar-40!" ;exit(EXIT_FAILURE);}
           }
           break;
         case 29:
           if(A==63){
-            if(mode==0){for (size_t i = 0; i < 2; i++) { pars[i]=Cu_sph[i];} }
-            else if(mode==1){for (size_t i = 0; i < 4; i++) { pars[i]=Cu_def[i];} }
+            if(mode==0){for (int i = 0; i < 2; i++) { pars[i]=Cu_sph[i];} }
+            else if(mode==1){for (int i = 0; i < 4; i++) { pars[i]=Cu_def[i];} }
             else{std::cerr<< "Error! Selected parametrization not implemented for Cu-63!" ;exit(EXIT_FAILURE);}
           }
           break;
         case 54:
           if(A==129){
-            if(mode==0){for (size_t i = 0; i < 2; i++) { pars[i]=Xe_sph[i];} }
-            else if(mode==1){for (size_t i = 0; i < 4; i++) { pars[i]=Xe_def[i];} }
+            if(mode==0){for (int i = 0; i < 2; i++) { pars[i]=Xe_sph[i];} }
+            else if(mode==1){for (int i = 0; i < 4; i++) { pars[i]=Xe_def[i];} }
             else{std::cerr<< "Error! Selected parametrization not implemented for Xe-129!" ;exit(EXIT_FAILURE);}
           }
           break;
         case 79:
           if(A==197){
-            if(mode==0){for (size_t i = 0; i < 2; i++) { pars[i]=Au_sph[i];} }
-            else if(mode==1){for (size_t i = 0; i < 4; i++) { pars[i]=Au_def[i];} }
+            if(mode==0){for (int i = 0; i < 2; i++) { pars[i]=Au_sph[i];} }
+            else if(mode==1){for (int i = 0; i < 4; i++) { pars[i]=Au_def[i];} }
             else{std::cerr<< "Error! Selected parametrization not implemented for Au-197!" ;exit(EXIT_FAILURE);}
           }
           break;
         case 82:
           if(A==208){
-            if(mode==0){for (size_t i = 0; i < 2; i++) { pars[i]=Pb_sph[i];} }
+            if(mode==0){for (int i = 0; i < 2; i++) { pars[i]=Pb_sph[i];} }
             else{std::cerr<< "Error! Non-spherical parametrization not implemented for Pb-208!" ;exit(EXIT_FAILURE);}
           }          
           break;
         case 92:
           if(A==238){
-            if(mode==1){for (size_t i = 0; i < 4; i++) { pars[i]=U_def[i];} }
+            if(mode==1){for (int i = 0; i < 4; i++) { pars[i]=U_def[i];} }
             else{std::cerr<< "Error! Non-deformed parametrization not implemented for U-238!" ;exit(EXIT_FAILURE);}
           }
           break;

--- a/src/include/params_gen.h
+++ b/src/include/params_gen.h
@@ -41,7 +41,7 @@ namespace gen_pars{
 
   const double TMax=10;
   const double TMin=0.0;
-  const int NT=81;
+  const int NT=101;
   const double dT = (TMax-TMin)/(NT-1);
   const double T_tolerance = dT/2.;
   const double Q_tolerance = 0.;

--- a/src/include/params_gen.h
+++ b/src/include/params_gen.h
@@ -55,7 +55,7 @@ namespace gen_pars{
   const double DP = (PMAX-PMIN)/(NP-1.);
   const int skip=2;
 
-  const size_t routine = 6;
+  const int routine = 6;
 
   //DipoleComputation
   const double pref_glue = dA*pow(2*M_PI,-4)/alpha_S/NC;

--- a/src/include/params_gen.h
+++ b/src/include/params_gen.h
@@ -41,7 +41,7 @@ namespace gen_pars{
 
   const double TMax=10;
   const double TMin=0.0;
-  const int NT=101;
+  const int NT=81;
   const double dT = (TMax-TMin)/(NT-1);
   const double T_tolerance = dT/2.;
   const double Q_tolerance = 0.;

--- a/src/include/params_ipsat.h
+++ b/src/include/params_ipsat.h
@@ -31,8 +31,8 @@ namespace IPsat_pars{
 
   const double RMaxTol = 0.2;
 
-  const double KTMAX=10;
-  const double KTMIN=0.1;
+  const double KTMAX=50;
+  const double KTMIN=0.01;
   const double KTDIST=3;
 
 

--- a/src/include/params_ipsat.h
+++ b/src/include/params_ipsat.h
@@ -31,7 +31,7 @@ namespace IPsat_pars{
 
   const double RMaxTol = 0.2;
 
-  const double KTMAX=30;
+  const double KTMAX=10;
   const double KTMIN=0.1;
   const double KTDIST=3;
 

--- a/src/include/params_ipsat.h
+++ b/src/include/params_ipsat.h
@@ -31,8 +31,8 @@ namespace IPsat_pars{
 
   const double RMaxTol = 0.2;
 
-  const double KTMAX=50;
-  const double KTMIN=0.01;
+  const double KTMAX=30;
+  const double KTMIN=0.1;
   const double KTDIST=3;
 
 

--- a/src/include/routines.h
+++ b/src/include/routines.h
@@ -18,7 +18,7 @@
 namespace Routines{
 
     const double chispar = 0.5;
-    const size_t calls_miser_min    = pow(10,3);
+    const int calls_miser_min    = pow(10,3);
 
     // GSL VEGAS  args
     const int INCREASE =10;
@@ -43,12 +43,12 @@ namespace Routines{
     const double flatness= 25.;
     const int seed=0;
 
-    void make_vegas_gen( gsl_rng *r_ptr, gsl_monte_function f2b, double * xl, double * xu, size_t DIM, size_t mc_calls_def, double &result, double &error)
+    void make_vegas_gen( gsl_rng *r_ptr, gsl_monte_function f2b, double * xl, double * xu, int DIM, int mc_calls_def, double &result, double &error)
     {
         bool MCcheck = true;
         int counter = 0;
 
-        size_t MC_CALLS=mc_calls_def;
+        int MC_CALLS=mc_calls_def;
         do {
             // ====================== THIS IS THE ROUTINE =============================//
             gsl_monte_vegas_state *mcstate = gsl_monte_vegas_alloc(DIM);

--- a/src/model_gbw.cpp
+++ b/src/model_gbw.cpp
@@ -122,7 +122,7 @@ namespace GBW_funcs{
 	{
 		double res=0;
 		double p_t = gen_pars::PMIN;
-		for (size_t ip = 0; ip < gen_pars::NP; ip++) {
+		for (int ip = 0; ip < gen_pars::NP; ip++) {
 			p_t += gen_pars::DP * ip;
 			if(ip==0 || ip==gen_pars::NP-1){res += p_t*p_t*gluon_density(p_t, pars) /2. ;}
 			else{res += p_t*p_t*gluon_density(p_t, pars) ;}
@@ -191,13 +191,13 @@ void GBW::make_gluon_energy(){
 
 	double res,err;
   density_f.open(densityname.str());
-	for (size_t iy = 0; iy < config.get_NETA(); iy++) {
+	for (int iy = 0; iy < config.get_NETA(); iy++) {
 		double y_t = iy*config.get_dETA() + config.get_ETAMIN();
 		parameters.y =y_t ;
-		for (size_t i1 = 0; i1 < config.get_NT(); i1++) {
+		for (int i1 = 0; i1 < config.get_NT(); i1++) {
 			double T1_t = i1*config.get_dT() + config.get_TMin();
 			parameters.T1 = T1_t;
-			for (size_t i2 = 0; i2 < config.get_NT(); i2++) {
+			for (int i2 = 0; i2 < config.get_NT(); i2++) {
 				double T2_t = i2*config.get_dT() + config.get_TMin();
 				parameters.T2 = T2_t;
 				double Q12_t,Q22_t;
@@ -258,10 +258,10 @@ void GBW::make_baryon_stopping(int k, QuarkID qid, QuarkID aqid){
 	double res21aq,err21aq;
 
 	density_f.open(densityname.str());
-	for (size_t iy = 0; iy < config.get_NETA(); iy++) {
+	for (int iy = 0; iy < config.get_NETA(); iy++) {
 		double y_t = iy*config.get_dETA() + config.get_ETAMIN();
 
-		for (size_t i1 = 0; i1 < config.get_NT(); i1++) {
+		for (int i1 = 0; i1 < config.get_NT(); i1++) {
 			double T_t = i1*config.get_dT() + config.get_TMin();
 
 			if(T_t==0.){

--- a/src/model_ipsat.cpp
+++ b/src/model_ipsat.cpp
@@ -284,12 +284,6 @@ void IPSat::MakeTable(std::string path_to_set){
 	config.set_dump(SETPATH);
   
 	if(config.get_Verbose()){std::cout<<"New config written to "<<SETPATH  << std::endl;}
-  TestDump(1,1);
-  TestDump(1,2);
-  TestDump(1,4);
-  TestDump(2,2);
-  TestDump(4,4);
-  exit(0);
   if(config.get_Verbose()){std::cout<<"--> Tabulating conserved charges in the IP-Sat model framework"<<SETPATH  << std::endl;}
   make_gluon_energy();
 	if(config.get_Verbose()){std::cout<<"\nGluon Energy written to"<<SETPATH  << std::endl;}
@@ -312,7 +306,6 @@ void IPSat::make_gluon_energy(){
   parameters.p_reg=p_reg;
   
 	double res=0;
-  int counter = 0;
   density_f.open(densityname.str());
 	for (int iy = 0; iy < config.get_NETA(); iy++) {
 		double y_t = iy*config.get_dETA() + config.get_ETAMIN();
@@ -334,7 +327,6 @@ void IPSat::make_gluon_energy(){
 						printProgress2(percentage_done1,percentage_done2);
           }
 				}
-        counter++;
 			}
 		}
 	}
@@ -362,7 +354,6 @@ void IPSat::make_baryon_stopping(int k, QuarkID qid, QuarkID aqid){
 	double res12aq,err12aq;
 	double res21aq,err21aq;
 
-  int status12q,status12aq,status21q,status21aq;
 
 	density_f.open(densityname.str());
 	for (int iy = 0; iy < config.get_NETA(); iy++) {
@@ -382,12 +373,12 @@ void IPSat::make_baryon_stopping(int k, QuarkID qid, QuarkID aqid){
 				parameters.T = T_t;
 				parameters.quark_id = qid;
 				F.params = &parameters;
-				status12q=gsl_integration_qag(&F,gen_pars::PMIN, gen_pars::PMAX,gen_pars::epsabs, gen_pars::epsrel, gen_pars::limit, gen_pars::routine, w, &res12q,&err12q);
+				gsl_integration_qag(&F,gen_pars::PMIN, gen_pars::PMAX,gen_pars::epsabs, gen_pars::epsrel, gen_pars::limit, gen_pars::routine, w, &res12q,&err12q);
   
 
 				parameters.quark_id = aqid;
         F.params = &parameters;
-				status12aq=gsl_integration_qag(&F,gen_pars::PMIN, gen_pars::PMAX,gen_pars::epsabs, gen_pars::epsrel, gen_pars::limit, gen_pars::routine, w, &res12aq,&err12aq);
+				gsl_integration_qag(&F,gen_pars::PMIN, gen_pars::PMAX,gen_pars::epsabs, gen_pars::epsrel, gen_pars::limit, gen_pars::routine, w, &res12aq,&err12aq);
 
 			}
 
@@ -399,11 +390,11 @@ void IPSat::make_baryon_stopping(int k, QuarkID qid, QuarkID aqid){
 				parameters.T = T_t;
 				parameters.quark_id = qid;
 				F.params = &parameters;
-				status21q=gsl_integration_qag(&F,gen_pars::PMIN, gen_pars::PMAX,gen_pars::epsabs, gen_pars::epsrel, gen_pars::limit, gen_pars::routine, w, &res21q,&err21q);
+				gsl_integration_qag(&F,gen_pars::PMIN, gen_pars::PMAX,gen_pars::epsabs, gen_pars::epsrel, gen_pars::limit, gen_pars::routine, w, &res21q,&err21q);
 
 				parameters.quark_id = aqid;
         F.params = &parameters;
-				status21aq=gsl_integration_qag(&F,gen_pars::PMIN, gen_pars::PMAX,gen_pars::epsabs, gen_pars::epsrel, gen_pars::limit, gen_pars::routine, w, &res21aq,&err21aq);
+				gsl_integration_qag(&F,gen_pars::PMIN, gen_pars::PMAX,gen_pars::epsabs, gen_pars::epsrel, gen_pars::limit, gen_pars::routine, w, &res21aq,&err21aq);
 			}
 
       density_f<<y_t<< "\t"<<T_t<< "\t"<<res12q<< "\t"<<res12aq<< "\t"<<res21q<< "\t"<<res21aq<< "\n";

--- a/src/model_ipsat.cpp
+++ b/src/model_ipsat.cpp
@@ -176,12 +176,14 @@ namespace IPSatYields{
 
           struct GluonParsIPSat * pars = (struct GluonParsIPSat *) params;
 
-          double phi_t=(2.0 * M_PI)*xx[0];
+          double phi_t=(phi_max-phi_min)*xx[0]+phi_min;
       
           double q_t=(IPsat_pars::KTMAX-IPsat_pars::KTMIN)*xx[1]+ IPsat_pars::KTMIN;
           double k_t=(IPsat_pars::KTMAX-IPsat_pars::KTMIN)*xx[2]+ IPsat_pars::KTMIN;
           
-          double p_t= pow( pow(pcut,2.) + pow(P(q_t,k_t,phi_t),2.) ,1/2.)  ;
+          double p_t=  P(q_t,k_t,phi_t); 
+          double cutP2 = pow(pcut,2.) + p_t*p_t  ;
+          // double p_t = sqrt(pow(P(q_t,k_t,phi_t),2.) + pow(pcut,2.));
 
           if(p_t==0){ff[0]=0;}
           else{
@@ -190,14 +192,20 @@ namespace IPSatYields{
 
               double D1 =(pars->dip)->AdjointDipole_k(x1,q_t,pars->T1);
               double D2 =(pars->dip)->AdjointDipole_k(x2,k_t,pars->T2);
-              double result= 2*M_PI * pow(IPsat_pars::KTMAX-IPsat_pars::KTMIN,2.) * ( gen_pars::pref_glue/ ( 2.0*M_PI) ) * ( pow( q_t,3.)* pow(k_t,3.)/p_t) * D1*D2 *gen_pars::GeV2_to_fmm2 ;
+              
+              // if(D1<0){D1=0.0;}
+              // if(D2<0){D2=0.0;}
+              // if(D1<0){D1=std::fabs(D1);}
+              // if(D2<0){D2=std::fabs(D2);}
+              // double result= 2*M_PI * pow(IPsat_pars::KTMAX-IPsat_pars::KTMIN,2.) * ( gen_pars::pref_glue/ ( 2.0*M_PI) ) * ( p_t* pow( q_t,3.)* pow(k_t,3.)/cutP2) * D1*D2 *gen_pars::GeV2_to_fmm2 ;
+              double result= 2*M_PI * pow(IPsat_pars::KTMAX-IPsat_pars::KTMIN,2.) * ( gen_pars::pref_glue/ ( 2.0*M_PI) ) * ( p_t * pow( q_t,3.)* pow(k_t,3.)/ cutP2) * D1*D2 *gen_pars::GeV2_to_fmm2 ;
               if(result>=0){
                 ff[0] = result;
               }
               else{
                 ff[0] = 0;
               }
-
+              // ff[0]= result; 
           }
           return 0 ;
         }
@@ -280,8 +288,14 @@ void IPSat::MakeTable(std::string path_to_set){
   fs::create_directories(SETPATH);
 	// Write new config to setpath
 	config.set_dump(SETPATH);
+  
 	if(config.get_Verbose()){std::cout<<"New config written to "<<SETPATH  << std::endl;}
-
+  TestDump(1,1);
+  TestDump(1,2);
+  TestDump(1,4);
+  TestDump(2,2);
+  TestDump(4,4);
+  exit(0);
   if(config.get_Verbose()){std::cout<<"--> Tabulating conserved charges in the IP-Sat model framework"<<SETPATH  << std::endl;}
   make_gluon_energy();
 	if(config.get_Verbose()){std::cout<<"\nGluon Energy written to"<<SETPATH  << std::endl;}
@@ -510,6 +524,18 @@ void IPSat::TestDump(double T1,double T2){
   double DDens=0;
   // int counter = 0;
   density_f.open(densityname.str());
+
+//Dynamical
+  std::cout<<"sqrts="<< parametersG.sqrts<< std::endl;
+  std::cout<<"y="<< parametersG.y<< std::endl;
+  std::cout<<"qt="<< parametersG.qt<< std::endl;
+  std::cout<<"kt="<< parametersG.kt<< std::endl;
+
+//Geometrical
+  std::cout<<"T1="<< parametersG.T1<< std::endl;
+  std::cout<<"T2="<< parametersG.T2<< std::endl;
+
+
 	for (size_t iy = 0; iy < config.get_NETA(); iy++) {
 		double y_t = iy*config.get_dETA() + config.get_ETAMIN();
 		parametersG.y =y_t ;
@@ -634,7 +660,7 @@ void IPSat::TestDump(double T1,double T2){
     DDens= T1*(res12d-res12dbar)+T2*(res21d-res21dbar);
 
     density_f<<parametersG.y << "\t"<<resEG<< "\t"<<resEQ<< "\t"<<UDens<< "\t"<<DDens<< "\n";
-    if(config.get_Verbose()){std::cout<<parametersG.y << "\t"<<resEG<< "\t"<<resEQ<< "\t"<<UDens<< "\t"<<DDens<< "\n";}
+    // if(config.get_Verbose()){std::cout<<parametersG.y << "\t"<<resEG<< "\t"<<resEQ<< "\t"<<UDens<< "\t"<<DDens<< "\n";}
 	}
   density_f.close();
   if(config.get_Verbose()){std::cout<<"-> Done"<<std::endl;}

--- a/src/model_ipsat.cpp
+++ b/src/model_ipsat.cpp
@@ -284,7 +284,12 @@ void IPSat::MakeTable(std::string path_to_set){
 	config.set_dump(SETPATH);
   
 	if(config.get_Verbose()){std::cout<<"New config written to "<<SETPATH  << std::endl;}
-  
+  TestDump(1,1);
+  TestDump(1,2);
+  TestDump(1,4);
+  TestDump(2,2);
+  TestDump(4,4);
+  exit(0);
   if(config.get_Verbose()){std::cout<<"--> Tabulating conserved charges in the IP-Sat model framework"<<SETPATH  << std::endl;}
   make_gluon_energy();
 	if(config.get_Verbose()){std::cout<<"\nGluon Energy written to"<<SETPATH  << std::endl;}

--- a/src/model_ipsat.cpp
+++ b/src/model_ipsat.cpp
@@ -176,10 +176,10 @@ namespace IPSatYields{
 
           struct GluonParsIPSat * pars = (struct GluonParsIPSat *) params;
 
-          double phi_t=(phi_max-phi_min)*xx[0]+phi_min;
+          double phi_t=(phi_max-phi_min)*xx[2]+phi_min;
       
-          double q_t=(IPsat_pars::KTMAX-IPsat_pars::KTMIN)*xx[1]+ IPsat_pars::KTMIN;
-          double k_t=(IPsat_pars::KTMAX-IPsat_pars::KTMIN)*xx[2]+ IPsat_pars::KTMIN;
+          double q_t=(IPsat_pars::KTMAX-IPsat_pars::KTMIN)*xx[0]+ IPsat_pars::KTMIN;
+          double k_t=(IPsat_pars::KTMAX-IPsat_pars::KTMIN)*xx[1]+ IPsat_pars::KTMIN;
           
           double p_t=  P(q_t,k_t,phi_t); 
           double cutP2 = pow(pars->p_reg,2.) + p_t*p_t  ;

--- a/src/nucleus.cpp
+++ b/src/nucleus.cpp
@@ -94,7 +94,7 @@ double Nucleus::nuclear_thickness_optical(double x,double y){
 		int NZ= int(2*ZMaxAbs/dz);
 
 		double thickness_unnorm=0;
-		for (size_t iz = 0; iz < NZ; iz++) {
+		for (int iz = 0; iz < NZ; iz++) {
 			double zz = dz*iz - ZMaxAbs;
 			if(iz==0 or iz==NZ-1){CC=1/2.;}
 			else{CC=1.;}


### PR DESCRIPTION
Added: 
1) Average Initial conditions flag. This keeps a state so that an average (smooth) condition is recovered in the end.
2) Boost invariant flag. This allows the output of only mid-rapidity observables/profiles.
3) CMake (courtesy of H. Roch)

Fixed:
1) Bug with the seeds. Now events are fully replicable once again.
2) Bug concerning P_reg. Regulator for IP-Sat model can be chosen in the config-file (Default preg=0.1GeV).